### PR TITLE
fix Lambda docker build

### DIFF
--- a/infrastructure/aws/lambda/Dockerfile
+++ b/infrastructure/aws/lambda/Dockerfile
@@ -19,7 +19,7 @@ RUN yum install -y gcc-c++
 # we have to force using old package version that seems `almost` compatible with Lambda env botocore
 # https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
 RUN python -m pip install --upgrade pip
-RUN python -m pip install . "mangum>=0.10.0" "botocore==1.35.36" "aiobotocore==2.15.2" -t /asset --no-binary pydantic
+RUN python -m pip install . "mangum>=0.10.0" "botocore==1.34.145" "aiobotocore==2.13.3" -t /asset --no-binary pydantic
 
 # Reduce package size and remove useless files
 RUN cd /asset && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[0-9]*//'); cp $f $n; done;

--- a/infrastructure/aws/lambda/Dockerfile
+++ b/infrastructure/aws/lambda/Dockerfile
@@ -10,13 +10,16 @@ COPY README.md README.md
 COPY titiler/ titiler/
 
 # Install dependencies
+
+# Install system dependencies to compile (numexpr)
+RUN yum install -y gcc-c++
 # HACK: aiobotocore has a tight botocore dependency
 # https://github.com/aio-libs/aiobotocore/issues/862
 # and becaise we NEED to remove both boto3 and botocore to save space for the package
 # we have to force using old package version that seems `almost` compatible with Lambda env botocore
 # https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
 RUN python -m pip install --upgrade pip
-RUN python -m pip install . "mangum>=0.10.0" "botocore==1.29.76" "aiobotocore==2.5.0" -t /asset --no-binary pydantic
+RUN python -m pip install . "mangum>=0.10.0" "botocore==1.35.36" "aiobotocore==2.15.2" -t /asset --no-binary pydantic
 
 # Reduce package size and remove useless files
 RUN cd /asset && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[0-9]*//'); cp $f $n; done;


### PR DESCRIPTION
The docker build in the deploy action is broken because I did not test the new dependencies in `pyproject.toml` with the pinned versions of `aiobotocore` and `botocore` in the Dockerfile.

https://github.com/developmentseed/titiler-cmr/actions/runs/11330576399/job/31508760367

This fixes the broken image build!