### PR TITLE
Fix tilejson bounds

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -102,6 +102,22 @@ def test_conformance(app):
 
 
 @pytest.mark.vcr
+def test_rasterio_tilejson(app, rasterio_query_params):
+    """Test /tilejson.json endpoint for rasterio backend"""
+
+    response = app.get(
+        "/WebMercatorQuad/tilejson.json",
+        params={
+            **rasterio_query_params,
+            "datetime": "2024-10-11T00:00:00Z/2024-10-12T23:59:59Z",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/json"
+
+
+@pytest.mark.vcr
 def test_rasterio_statistics(app, mock_cmr_get_assets, mn_geojson):
     """Test /statistics endpoint for a polygon that straddles the boundary between two HLS granules"""
 
@@ -180,6 +196,22 @@ def test_rasterio_part(
         )
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/tiff; application=geotiff"
+
+
+@pytest.mark.vcr
+def test_xarray_tilejson(app, xarray_query_params):
+    """Test /tilejson.json endpoint for xarray backend"""
+
+    response = app.get(
+        "/WebMercatorQuad/tilejson.json",
+        params={
+            **xarray_query_params,
+            "datetime": "2024-10-11T00:00:00Z/2024-10-12T23:59:59Z",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/json"
 
 
 @pytest.mark.vcr

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -116,6 +116,9 @@ def test_rasterio_tilejson(app, rasterio_query_params):
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/json"
 
+    tilejson = response.json()
+    assert tilejson["bounds"] == [-180.0, -90.0, 180.0, 90.0]
+
 
 @pytest.mark.vcr
 def test_rasterio_statistics(app, mock_cmr_get_assets, mn_geojson):
@@ -212,6 +215,9 @@ def test_xarray_tilejson(app, xarray_query_params):
 
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/json"
+
+    tilejson = response.json()
+    assert tilejson["bounds"] == [-180.0, -90.0, 180.0, 90.0]
 
 
 @pytest.mark.vcr

--- a/titiler/cmr/factory.py
+++ b/titiler/cmr/factory.py
@@ -636,7 +636,8 @@ class Endpoints(TilerFactory):
                 auth=request.app.state.cmr_auth,
             ) as src_dst:
                 minx, miny, maxx, maxy = zip(
-                    [-180, -90, 180, 90], list(src_dst.geographic_bounds)
+                    [-180, -90, 180, 90],
+                    src_dst.get_geographic_bounds(crs=src_dst.geographic_crs),
                 )
                 bounds = [max(minx), max(miny), min(maxx), min(maxy)]
 


### PR DESCRIPTION
The `geographic_bounds` property is not available in the backend anymore and I forgot to test it in #40 :facepalm:. 