### PR TITLE
fix: handle case where UMM metadata is missing horizontal resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Allow POST requests from cross-origin clients ([#60](https://github.com/developmentseed/titiler-cmr/pull/60))
 
+- Handle case where `ResolutionAndCoordinateSystem` is not available for calculating time series request size ([#62](https://github.com/developmentseed/titiler-cmr/pull/62))
+
 ### Changed
 
 - Add `s3_auth_strategy` and `aws_request_payer` to `AppSettings`: <https://github.com/developmentseed/titiler-cmr/pull/58>

--- a/tests/cassettes/test_utils/test_calculate_request_size.yaml
+++ b/tests/cassettes/test_utils/test_calculate_request_size.yaml
@@ -1,0 +1,323 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - earthaccess v0.11.0
+      authorization:
+      - DUMMY
+    method: GET
+    uri: https://cmr.earthdata.nasa.gov/search/collections.umm_json?has_granules=true&include_granule_counts=true&concept_id%5B%5D=C2723754864-GES_DISC&page_size=2000
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAANVc63bbyJF+lT7cP1KWgEhKsmTt8dnAJEzRw1tISs5kPPGBgCaJGAQYNCBZ9vE7
+        5Rn2yfar6gYIUpQsT8abrI8smkBf6vpVdXW3v9SWYaZqF816LUuSj7WL02arXgszucLDX77UVjLz
+        ahdfaqm8DVWYxFYY1C5ajXotkJHMJL7MvUjJem2epCsvq13UvPU6Cn0vQ+Oj2ziwY095tr9K7Xy1
+        +s+/qSSu1WvrNLkNA5nyaLWuO/3Q6U3beLH0lOUnq5swluXIuSoa+lEi8cW00zOqsp2nVOKHPLEi
+        km+9NPRuIkmM1K6Pm6cvXoC502OrMl/5+Ph07+Pm2d7HJ829j1v7xz493z/2I1O+3E9gYz8lj7DT
+        2t+6MvavX+s1dWxFYfyRJaSOL46OFlIFofItP1/lUa4sKCqgX5n0oeyj7njwoX/MH8e9gTvpdt7Y
+        jbOj2q9aI2oN6XuRpfIbJbMsjBelcmK8uZVG35XuHxpnRp1Z6sWKdLpXo1YAQwyjB4r9UvOT2Jfr
+        TA+9V81f64+1qmr98VZVI3i8VdUmHm/VehZdVYt5gq7nUf/yWZJoPIvH50m19ayxqnSRMZIRVFSb
+        pTlMYKtvu3XWOj47PTl/cVI17xKbAi8DbNRajdap1Ti1Wo1Z4+Ti9MXF8Uv7/OX5X9B0ASPLIwmM
+        yWOA1cvzl8fG+uRqnaT7bbegIbtf0/B+EkVwB0wI7mpANbLJjpd5fS9e5N6C2rjxIgrVEjM6sR9G
+        kZfe/yTv75I0YF9zslWi1kuZyroYp9IP12HGZl4Xl/dBmkTJ4p6cql1O1TYNtM23U+llSYqJLvP5
+        fOWhX9d+a9eFa7+xxTRL/I8yrYuOPbPF6yS6DWN69dYWQxl9pC9vPf8joFjMPIJjNwj1aE4cpPJe
+        TL3bzF/K+GOCl8QZaFQy1hS8gYuiaSdcgKRITP1QQjyCmqH1KAagyIlUSZ76kiTTB8BooSyzbK0A
+        MoQw9kLNfR0bFsntETTnbeR6tIMQ9jJbRSTscX5DYpVEazcJAi8NhOul2bIgQzEdwosD0Yt1gMB4
+        YirT25DetsGFTMUBrEeQ9RyC5FmYRVLDkuA5xZswBmdbihH9Y9EUgXcvGjY+5SKVUnyqfrlmJMNM
+        oVRDbyV3gA7vJgiZnpKd0kqPrcaZ1WzNGo0L/rEbjQZZ6bVMyZ7RiMc0/caR5/OomC2+kVFWF4MO
+        XAeTatx1P2WSrPoLmrCZm+cTua7oj/zImczcac8ZYvDLJA0/J3gXmdadZOWFMY8iE4T/9J7+3U5g
+        uxBLJqf3Cs6yM8pr+BNeLyZQILygwOZ3UmXFq80ItQureY4UYphAc/tev8RL19vflXtOk3x/T+tl
+        A1jy9WvVdcZpAgUpRfbdnvWuXVITqCTrwbsg97PS1Y0ZVXwVrGPkRUJiqLlg+VJM2z132KZhZsk6
+        9Gnc2WA0HV+6E34o2UHGE7fdG/dmzqw3GjIO/i4DwToMRvblrYyauw2EMxhdDWf/hxNOnJn7Q6eb
+        jvq9jniyWYuaDUfvfigd/d6frp5DyMTpDdkvZyaoaMfU1jSBezAEzMKV8ZLXchHGMSy5eIwxmi9f
+        nluNJn520AHmjZFht4AzhT48K3lojyLkMaFkZ9TjkEQftWbDPm28OCNIPTJQdNRxfj4CsqDpdAkf
+        3I9WbgzX//2wEZhbGf9QeJkoQLhmgF0vGiZyjrhIWM7CceDpOtIl8aIufkaQ+8kWfVtcqrwupoh2
+        SZokahlSECTc/7Mtul6yPWYJuY2TvULdBIFtxlyVhSaEzNNkJSZyhVQ4QoSUsZKIMStEtvReXJEm
+        MLtw0iych8hZI4TaPOWPDFDyUbSjJA/wGzkttTBxSWNpETYwP2K0gwWULQZYXYGziAwsiXLW0Mkx
+        sYUpqWXz/PgEOHraYpvfiGmTEAjKCCa2QErgBJFOCEQlI0CLbk6JgahkBhDumJrc8SA/Q84sd5eH
+        KTMLEjQGe22Ld0k0nz8m7bNvSHu2lGI2GQzEII+y0FLoGEVYfO7YlwOTu1ehuhB/yj0VWt0oufGi
+        uun1s/RAUVuvGgOLVJOkYq8ikQHA7mDCEgmDF0l7R/ScfK1Y8nZV8OcHzcOK6I/PrdPTbbG/Te59
+        ydImoUOCfw6lFhOGJQl7cXIXeh8fkVSz+Q1J/eRFUAhIjyh/ee2R9bUHo8n48pksNFtV2zk9QeJx
+        +oLsaRctms2z06O3lwOrYxFVrZbdrH3d4nWSB1B6HdrXHF7BMPxlLGlF/5glnH6Dv7YX+XmklZXM
+        RTcNgwAsbmuRcztkdSKD3WgjEEi6ofM8nSM5Mn7Yi61pmOWAgXwhxQj5fHprkueKrAhCbZqLBmtx
+        wgjRIo2wzaxk2+lHGrCbJvmav6llsq5KFQuN1rkY+VlyA7UQvsAqExpI3sMmHVUReuu4abVOzjgy
+        wI5h5/fGBf6uv2liQgXUTLFYDgCpIbBmrXMUgRcqXIVYS4gsYaq3+kmhc25BuTSce4O2l5dQUEhJ
+        Oo+OH2r9vsZQ/r4mpHGOYhzP5+U/ngSYvKqAQvbA+roImaQb9BY5meMdVgxiGS6W9ITGSD3/XjA7
+        KkxloI2FuoOFBf1GVESLg5ZYQWRLdSh8mPgNyEyAVjQ9WXBvOuKobaJ6qOs57X5v4MxG/VH356OB
+        O3NHE/3vSmCHmDuY1886ocrS8CYnFiqrArL6CUIvp8S5su5At0VeMj3G+ipAxAaMK2fcc+NgnYSU
+        WW+WMJCxbYoltqQVCD8p1zPq2N8MsWfITgIRFxn51aT/W4eeuE5nwAnt8esc0JxhBTe6+RuYhg3P
+        w08U2v/56g4SBcenfKMNH8pSLA8yLsR0pPLTcG1WFcMklpRTYLlCurtKIx3Bt1t12KadiontR2px
+        wOZ5qAPvJv84eCTHONxJMCCTHbkmPgGBTDfCTehzI9k1A9cRBEIC5IzpJk3ulHywHl3HCz1+m3w9
+        zma6MnAdKvLIz6VWgW/6TdediYnbR6bcEde96ZXT7/1lszDYlpAWtfGzDEifwVV4pSPWgBItEEZA
+        kz+JO3mjEDXthzz/tpV2SXbHmTliCtr7zrDTG3bF2Om6+zjfrLaIgG/yJG5DT1zOZuPpA5IX61Xz
+        UQ1R30fNFE6Q32QVwmcT191WAT3eR34VIZ7PAH0ZjeWw44wJpJEbcbr2Hfwka4ll6PoxlnxNpCq0
+        suFvNHZ5WsOQYeNq6kJbk+te2xUAmd/GKQWkbup0pjrcTtln4Fyd6SGBOfIY8J1SKFhRwCgEkC2R
+        WZm6PgJVWUVj0FfISPAPncUJVVRjPD9NjFB18JXZQxt+2iCSQD2w4RAYvyWt7oTZ0cY8uXYnmp3f
+        WXCPmcjscuJ2OtPv5CxbAuXBHBIpL0oWR94CKLfwHjgt24lu89BMzNQ/wkyulGTu3CJCwVK81F9S
+        bjIPoXPSeyoxChaoWiCwiFLnK0rd15F543NZTj0UkeIx94ZBfvPff3/1cDdhw/8ucb8XGsw0+lqM
+        vmy6nk/7G0KXP8VWIBDOENIYGuPn1pysHnTD5NbDwl/7FaG4dcOJfZYkkXYoL4oQgCi/ShVJln3o
+        sxQLkx8zb+GGAITWRJNwFyJbzzOx9G7JC9E3SO7iKPFIM/fccY9FGop2YsZ/UGtTE3u1qRBUHKw3
+        unaGw95zAt5z4iZJfJsyUmSegiN7vVYPnKVIp5QucXy4bpx9cGavOx/mlEPY62C+Ra7T744mvdnl
+        AL6JzNGd9dpOX7x2pj24yqh9NXCHM3FAA1Qw4rrnvitZ6g3fjCaDRxmqLIH2G5DOZWYSyya0i8RW
+        PvhALd/HfDnq1qCPiGLcKzkuuPlx/JpVD3wgkJ9+nwSNB75uvPjwp96/ire2dys9IBstjjSfkut9
+        5PpwzURXOOChvzPHNCxGtXw9/7+Kfb0EKS34tyd0kMaRHszGkwfs0Ctr4P5QAzU7LWKIJZHax8mG
+        8tRscSmi2/hfuJLpwrptnFmpHsiKzUAbNnqD8WgycwAwwxFw50fxQwsmisBrYEeMdE1xVYzTtxVy
+        hVwJhGVaxu1hEoGoxV/3wk1GX4+c12y91PxDOebDBMQZjgaAfnf6A9kca+cQl5RkUrHlScVtCBlP
+        Rm/d9kxcjmC+z1zY/Kr3Q6muZRa325t5+ypcZiDYr9kneXafq3GH+2BW54YW3rRTVXsfm/1B0Tgr
+        ijl+nqYgWtyaN6aSU6RdthhFAazAvFbIDqJIxImIkniB5zfIzm+xMKdtDDYbZA0ST2WMTH6NTpKS
+        jZt7sZnZfh+/j2cmc19wtWaniuvCnTj98yINjqSsA3a0QwOUnPcMnalTFrlMLYpSloUu8ClT29uu
+        RKVFMdfjkpMgd4zyonzYsJv/8w+y8PQerERzC7GTuDT7LFSoa9hC9LiCRS5SCOxvVOdhiqy3zp+d
+        osi4XaIYwLXzVJLPc9HhUKxCpXj3PucCJC/OwWw7STf1xwS0bArcntabMvuQlJ+Zc087jCaV8qVe
+        +nuxzvhifgjqfKrKYNyyelpOowxBXoC0zqfMknODv+dSEfusA1Nz4xIeaUmL3VJUHxeVw1yKaL7D
+        uPSZ0Jow5eKZ4lRTKIgRyIkBYFaAP94SK5VX5QIzk93MiVdzYkhXBs1u2Y4uNZVsySYbhuBWJLCb
+        7VKlKYpqwotS5oZ+Zi6M/VRyjq0+wgVKISxZH1RTmuQFR7deek/C03XKEMIMY6JtDR4kJ+OwQrgP
+        zVWdJ5YyUBd4tw4Dq2y/JckDLEyQqmOuujixlkUp9LAO1a3kUYwEwqL9tO1OfSqLcZ/mdicG+kRl
+        mA2agwNJolMvx3QZTXc7tk8tLrWWfSGAd8sQ8tJioHXPrdTeSlaFhRCXaGmCoqJbr1ixLLdVIINt
+        u/Vg+vLTmiuLJCxGFKiPYhGJXpsQDPozgwybiaqTE2BV+AnGkFKdUfPmJ56isyafk5gN19GGWNfQ
+        t4QSuEoPj9uQtuMUNBkLZgWxwn0YbqAV2q8DrCqz3JrPKZKoLA9CFoOv/Qcj8ILVuodQ9YwgRCMg
+        FbhNmc6AMRHC27Li2MhV/IG18Aehq5+i2RCf6NfH1e62aFH6L4t8JXyh36YplfTZi4r20DcIxIc5
+        6qEp0brfre/rbYWVhOM/BFUy8tUKidm9rSfY8KYxWgeCeZiqjLWVZwXkPTHiAYYkJg7pi8ZlWsJi
+        4U9qNPsCcVEVuC9GNFxhvtYJMwwqVmEcrsLPUnMIs1chIU2AIW9Cj520DHM3ck4Q/L7WOHtfq9Mr
+        RohwpSsPJIYsySg+aZMHNYr2MdAn0rUccHRyvqWELUAmK0d8C4Pq1ogWHCyPturymM65wq3hyeAK
+        DDD3KfU09BjgD8CanyZ3Hp2TjOfUwlRR4AhiwZtZhTrqojgpB+a2RE58an9dr2GsLA/elEmJohCW
+        TS40W+aK5bFKSI0YsigywEZM4H0wsAZhkzpk9DckF6JqQjg3m/a2VpKfpKlOm+piCae/pU1jPNd9
+        mG7DPNFmFRtZpQCKyhHt8lY4Hbx7wKvWFo2U+DoL8tnQt/SnVVTVIisETCO54ZMLhV6gCyCk1iAf
+        ElSF13x7DIY4L7rz7pXOnUw5NKCISXkYQiT5Q8GQNvxS7NoetYyJJwTtUFeDkKKAsiihMJIVS0sO
+        d8CsUjxmMNqXo2zCbKhKY2Ksjx3v1DNyKkV7+wSGMFEd/EyiV7hOsXMYAIJJdSZfM4QUPrlxR2RE
+        nKRgQnNwsZqTbsmXPAEIBasq5WVsQ+9k3uQZfbvnhkkMiheAPJ5XO4X26UXM5yqM+jc4x+zVTTmS
+        o0JKiWYFCAwEhHOuUydcPFNLqXTRDA9tUSS7xZ5lMYNB3214L3LZQFJ5X1H00I2jkG3MdNahoeh6
+        SYZ1qQ2rGIDwvoT7Yge3RBYShxlTi8wTN17mL+uCzquyVepgX0ATGQ768MO6VnO+JiZPzAZswR5C
+        fKL9/KackdkuRtJxhbmti3WE1aR3Q8XG1okg3ygBRtoLmztQ09AkFm+9OEdqJYrMs5olaNCiFBIf
+        6JFqF3bWaRiJltZDoYtKGGO3OtBh61BUdtC/M1JthSlvE6Iq6A7v5N3v58csEgT13wl7cHKNGDt/
+        iL0x8/aByaQ/r8T0avBlHIo/iOYv+GAs+vWrOBKmpY+lCF62ToCyr35p1ofzX2mcdwSOF+V41EoP
+        VR2FJwy3ibC2gC6MIbt6GcfTw/fxcL7bYZiv6AwEjLvadR5WELIuhvNXJ+fv4+Yv9q/bvXtxQIku
+        xDTPY8aV/xJNfaQAtBE6E7F10RC8/QQHlVtsPSBCw3W6WYHuaNSQxElct3iqDfRuGSJx3gz+qlHX
+        ICUzvbuB7hgyL2OYdntmFeNR8UhD8zh81dBrXE0Nd7IrCibKaeR9wGdE56kS4dVuSKb+CMtkig9i
+        o35XN6l8qtchtIlMOQ+5QJlr9CaWxlEaZ/OYkXYjP4bsfwcMpsiY6iBKZSyOtpuZsGxghvMoYGwx
+        qW8loTanZKpGimVcgLe670El39AvXHr+vnZYJMSbeZ7QGyVBRQg26Dz31JKgZucUz5PpuA2sBX7V
+        N7BVHPZBzkS4X+Vjh2BRTUqZIAbB6kkcDVYEXfDsv7bIt3XDGGBlMFm/IWS1NfAT6OvpRZoketnj
+        fTTWILMqChrIoM4XbPeQ2wfN8CvxhaFIHPDD8PCvLQ1v/M2AkzgUhHJDGPMHPNcY9/WvDfu0CnSb
+        1xreDh4OQ5PfFWjIr95n77O9MLcjxfoG9DbUU9eBB3OnfHrb1tky6iXbG+r0hLsItSlPaZMql9RE
+        sbPgNTDrO+ft9kLtu6o2sbTiXYWa9Xb9ZqVuWhYRclOx2lQATWK2F934gF+KPK84v/mg/jct1+BP
+        1P+8iM5yZctVcUBsEWtriyhMegZRvlHn2nIXrrnfekDUSvmLEmG6KwPuuNbJAkoD6pwDq5J0RXAY
+        ruSRWlOdqthX3XbEjfAKh6IlktR4sMUJVwzQH5143kK2fEquXIcjNEiPtsqpIAGW1nV2bd0YL/XJ
+        OlpjeaId6T58GGPC1EOvEW3uLpZaSIGEcEIOFctklSxkTMDoFbzicZGW045vP9EFpcfuOHTdUXfi
+        jC97bTFxu1v7Rt3+6LXT3z1j/80OfHro+3uN2q6jz9EPsIYIHim7t6zGidU6/c6ye7O1797NrNhp
+        oj2KfaX6x/tUSvU7t3fM9oSme+e8PasjXhQPvlFs5tGvlHzyFN6sOJNhCs9kVPqY+SNXo/S7A3c0
+        7fSmhzqE0TKSC28FFYs8DDiskwNwwV6f29BY4vHJF1rnZqLYc9lzZEPGCzg2H3qiq3qeVRwEslQy
+        z+6Aa9Y6iUIqtfLGoAUyrGJmxB6u324ox88yuePlcYoxCcF9Lq1zsfJjnNxFMlgUQbkI/0x8cXKu
+        Dh+ZS47E3zgyx3RIOlmh7BpfL4ozz88QEVRxKW+SmLvGPQRPuPqCr+hBZRzBCx27ownvNPW98tnl
+        1Zs3A75GZUbdOaTqBAHdXzKmP81SKbPqs5rmydyHmzKQvYnCxTIz990w8oAuz2bJWrxotvhmoT59
+        XN4l03eiMjmmjCbme2aDDllvQpXXdhJoNzg7azKZecz3wmpXU4et0hA+kFQbDZW5PG58YwZgXi/p
+        dChdlkEKTEfoG03rRfPEenHcOGdPM23feJ/2tDo9edmqtnJXYKfSriuTdCHtt7a5/fDHcrePboPV
+        K7opoESY0+w76gFQTdyft9Uzda5n7Ut3+NPot2uoPFIEJ3H0USEn9Zf0aa4kziTl6GgEBHjon0r0
+        scJOeReJqUDW8aLZsOm48je1/2+k7tOzxulTitQXUO3NBdRtTZrtV83Xjtc5k/Zl79qdELtVmCXx
+        HHWnb9pHU7dz5E47R7PetH8ECDB3j6oI/M/cKaVXjELFKB3HaR/Wv0Oz9QcTh/pmc728ZktUuJ/W
+        EfXgKxF8wp2+yfpTRlBn4HvUgHfPbD88E1eKfetc887e+dNHj+myyfaJ8SoWi3f6FLO+DG7I5JsX
+        O4pmbRihm2akc25aoqwZ89Ltj0XHnf6EZcGYDl6I7mR0Nf7tjvxPWMj/a79ttU6eAdOtF+dPeTeZ
+        gxVE1lJGa4sM5I/UwN52cb7eCGs0/xXEhj5zukBf7yquhNW2nZ1XF9s+/V3nE+i+Ca+fVuWFzS0s
+        Gc2EMx73e23ndd9lEa9oKRSM5g/a7iVX8P3Nak47XSPbKy4Ekgluu5EfxPtOv+ZYXVZO8d827ea5
+        fUJGpSe/Ggws/p8/ylzUtKCrHDrwAGqfuBjzBss903DrDd3I1As0ajENP9OV7FZ99+EVVsYkg9eg
+        4U3xP8PEMmvzwVH9xKh1yP8zCOsef/8X6KXMx5BGAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out,
+        CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+      CMR-Hits:
+      - '1'
+      CMR-Request-Id:
+      - 7b97f116-d8d8-422c-8c70-916199a72cc0
+      CMR-Search-After:
+      - '[0.0,3200.0,"GPM_3IMERGDF","7",2723754864,20]'
+      CMR-Took:
+      - '513'
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-MD5:
+      - 2071effb73ee49322daf291442d2dbb0
+      Content-SHA1:
+      - 6215294dbd9234848ebb39a279dd659a03a00eef
+      Content-Type:
+      - application/vnd.nasa.cmr.umm_results+json;version=1.18.4; charset=utf-8
+      Date:
+      - Wed, 25 Jun 2025 17:54:31 GMT
+      Server:
+      - ServerTokens ProductOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding, User-Agent
+      Via:
+      - 1.1 cce8cd0440c0a4829b58ff68a1d1446e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 1vKbOkXRHW_rEMqguIWR3J7R44NvFDGJRRmuOrgsWWVvuVXZsIrmoQ==
+      X-Amz-Cf-Pop:
+      - MSP50-P2
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - 1vKbOkXRHW_rEMqguIWR3J7R44NvFDGJRRmuOrgsWWVvuVXZsIrmoQ==
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - earthaccess v0.11.0
+      authorization:
+      - DUMMY
+    method: GET
+    uri: https://cmr.earthdata.nasa.gov/search/collections.umm_json?has_granules=true&include_granule_counts=true&concept_id%5B%5D=C2036881735-POCLOUD&page_size=2000
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAO1a/27byBF+lQX/SmBREmnZkowWLS3RMq/6VZJyeikOwYpcS0xIrsofcnSBgb5G
+        X69P0pldUqIs2sld0zSHFjhAZ3I5Ozv7zTff7OaTsg6yVLnSGkrG+QflqqP3GkqQsQge/vWTErGM
+        KleflIRtgzTgsRr4MLjTUHwWsozBH/c0TFlDuedJRDPlSqGbTRh4NIPBrW3sN2Oa0qYXJc08is7e
+        pzxWGsom4dvAZ4mwpsxng/FsMYTna5qqHo+WQcz2hvO0HLcNtgGNs2KcnDDdj6Npyr1AzJuix1ua
+        BHQZMlyHcqdrncvzdkfrdNTDdPun5xd1TzuXtU97tU/1WrvduqcX7dqxBws/NRRY9DbwpPOO3ut2
+        um29p12qf/nx7bu5PbvDMbBhoRjgjnWt3eto/V63uhB4rHcu9Hb38vKw6p8ewfi5GgbxB/HthvuU
+        eirfQOTzKA/zVIXdyZgHm9saGRPHMd7pvQ+RalzPJuq4o47Gs2t129ZauI81H+dL2P7PfPmT3MJ0
+        A9tFQzXNlynLsiBe7XczhjdbJvd9dGs7jns2ZlsWnnXOKqbPRiFf0vDshuexL7b+zGH0zMmTe+qx
+        M5dFG5bQLE/YmRHTcJcG6dlWa7bPYDCFKc9ejYaO/rpAVJbQOEVY1YJK9SEVgvAEW58Uj8ce22TS
+        2TqkPTaeG1QB3vODKjh8YVDvSwbpX+JT9wsGVTD8gqXKdMeYfvJFLcIfKxB/Mr4W8Cd+1OL/ERMA
+        d7uyh1mSw14ffTvQ2+eXvZ7WPaKGPQsCfoChFL2tX6jtc1Xvurp2dd650i+bFxfttzB0BWDKQwZ0
+        lgNlXV1q3U6BMgAlT+pRX7qQ7TZo3uNhCIkIE8LiFOBPxN4QoDum8SqnKxzD4POGYsReEIY02f2J
+        7R544ovUlokCbwlmoPhdOPCDeYg/Iq0U3BdKUpkyJDukDLyR7zFHMGUHe3cGQVYSLWzNHUswKOAM
+        pBbyTpCFbJ+3ZNwhRp5CcoXA3kRmLJnkYRaoDotTnhAcVeYneSXdft0gPqTbrkG0Vof4bJUwRhKW
+        8jAXAQF3EkYznsBEFfPX4DjNCb8nEyhPPOEhX+1wJSwJWDqlUdUxJBTSIXLC0rMDlxDgElJwCalw
+        yd5XsGtDGQQmGZZ40Ppqu69qPbfdvhL/NdttgYdi4DwEY1/gcgP+CJc8T2LWOIQP7MyRX9M1S0Th
+        bA4NYwBPZzEQOrMhPHmC9j8pYyB4iZB1lm2uWq2Hh4fmkkfNFd82ad6ipc2Wt6ZJlraWOewuoDFt
+        0Q1fdrvNjX+vPGISGr4fYDxoaGRZEizzrMjhIpyMJiEEN3tXYP5dmoHFd1kQIYaGLPWSYJNJhJjF
+        WDKSY4mDY4kLYwlQLymIuYmVkYa5DGq7p7a7qn5+ElTMBVfmytBwTdeamIIGCsdC2JWKWyz2650a
+        i3EVl/imZcb+Z7zSNbV9oeraL/UKjb1D12Jvd+LKUM5Exvv3+wk7x6atqVu1KgFOxF/PGfWKtCWp
+        HBzLweUMXzEtKn46rm1NR1VX58gXKawvI9bwWWefjiq9nM8Q8+roFvxTOzeGZtTPB8B1pL4wP6IV
+        TIriwYBvwecVK764ndnW29nUNcZg6ZYnwc88zmhYDB7yiAYxfj1iHORwssP/H3Bg2QBUCnN24GSE
+        JcOwXdOxjClYucZoAbPbwJfA1aVSmPIkW5fvDiaUqz6Ap6G8ARTWvQU+Ee9NWv++eO3wvN66iuZF
+        4bP3BGrE/ukaPj3Zi3nC30vGJxirKzLYAc/4Cej7ECGqjnncIJVRQ6GRrojNVjmUI9Ju6hclea8S
+        qKwNjCIoqcCbwE+IUx4iDruYRwVI3vAk9Ek5mEgPCVR8TAMzDINNygO/HDxyiHjhsCiY0Pc8MT4C
+        Dq8uz7s90DMYnCGLeYSL5cns/gbSDzCBG4SQVq70fg887er6+eVj49gjeoiZBEEMyeMdHsqd/csQ
+        uCKWZRAX3VB+PHmyiANskIbMCyKI31CEJUVF8giTFuxToM5mGyh2AFtabMUBXY/VSgyxBytpiiVl
+        4Fp3JgYBIOfTxId3fu5le3XheAFwCqtIBMAx7P6KI6YVE2a4Jc7AMqcDNOPyTeDB89nANKaoG1yW
+        ROXfxDUnc9M23IVtiuSUYkpwh4ZZaBrEWdg3xsB8aaj+ZOjNbDEFzrRmxxNgMruFbpLZLL23IbdE
+        7UWmlo+u2SqIcWfLxy9VEAg9WIY4gSpN4RvhE+6yhRqwg6EeziyRF/ijaO3mRfuy2zomHwPSDhCT
+        7Ypim0K19XnQ5MkKLTjwMiuVxwttEeI6Bnp5Kp+O6Fh8+is4mWDbU9Yxsm97hJqQzbrN7lmC+JBx
+        LL2YCVOi+hMr2oQsKkGJiqVwpKJmjoXd5ytFVc/snQX8AqswP5CssvchBbEkVQqZ8ibpdvfRh6/f
+        rnm8ArEU4K8wcQuaC/QVW63S47Xu5RrgQmurbf2khp8KqmIH92EiCxvrxVfUWcMggaQeQtETIgv8
+        tGJ5ylFwD7CqJAPosx+gVqg6Zvv5de59YBkQ+myJPAyBuw8+orv/1QbfOQeB7gNYgM1SY26BoNrw
+        AOvwPklo4q2hy2/KWZqgI7M1QlSeGUEAW+m5dzCinBodcnCrBCRuyK82bpvGUOg0BVQ49euaLJDw
+        gBt/kRQtaSEf7izzDbHNMUi9IbGmNzN7IhisVtmQRcoENssWiozyAAohgA3XB0sYQOEBnwrjFdBK
+        vDn5MttrS4MMLFfS5WhhDc2xNTUdaaYSiSIC7zfhYe0wPfCd1FJCmx27WlQ5Ily2GfVBjH2Re5+P
+        yZMF2ObAmpsnPq+CbJ0vmx6PCvdbuCVqIl0hdS5LuizEyFd3dmROoRqNyXA2WEzMqVuOOLhd5P5q
+        naRpVpD/iZMJzzeipbgNVmtyUBHPUmWVAr79msRWyAVV4VOzslvXnTuEFUm+75rIMuEPBeR9/hCH
+        nPp166iy3tFCRqZLECinyHFt8xQ3eNBck+rbIMlyGqq+oFjQO63D2Uraqj/sGbEM4Y/Ee1Mebk95
+        RorDa1zGBPRF4WfGPmatdRaF6GjwM0PR195rvsk1UPxJzK5lbIr+FLoy5Cw85IAamhIocma5EoQH
+        vPv3I1dvsRJA6UQtXYo3rcLb9A+b33+7uFWWVIL6znIWxth6W8+17jqPljH0InUhuwtSAEPwcyVt
+        Ps+Yc0lDWWk4fbEEwrcrIVsxFCg3jkrGAKqNa8q+9XBu1EOBqp9fXfSvtMvmZafzVqmsfTEffuE3
+        eGSzRNWB2l+BDv4Xk84rSaav9+LzmSNCSGup2Bq4u9BsMF+e2hEwDmKQV8Tjkgpll5Fszcjnjr/I
+        q2s+eU1yFOVgJRMNE/AKSzY8lHXz1cx6LaYhKylCn/aaTeKuYcbPSdS6s0epllPZc0KvEvspSSHs
+        0HZmTHzCl3iaXYjS+4RHZEOhhdgy8PI+oaArBOWVD6PAg1yn8H8J9QM8RsAq9gBFDtM8DbJcsqWw
+        lK6huW0QaLPvsUiTZc53UhNH0LHDk2JGDGSxOheULtTKKI+LYpCWHfOrkeu8bp76nK1hK9boEfu4
+        weOgGDcP2BEPXMqtfoBmn6QbxmD9kPLiq5hckqiVEj9HV4QTPoUNTyoj9OqIGECXEQgJWH8vZOfB
+        /RI/TQKbxRBERSdWZUGJqPtKswOLAfkLoIC8kitB8yFNVgxHIgIATzH3AKSIPY/zMCiaAj+Qzx5o
+        EuEzdn8PTqEHmA0BrFqcwkMnVkQKTac53mqC58ud8Hs6M4wWtMlzounNLoGWLC0+rqzIiuUaIezY
+        L4BH1R1oHAUA1hvSj7gaLp7bbBfz0Jfb7kQIlFdav995TSZAZWtYpVZiHaPhhRgMmTqY6Fr/UiMq
+        /PTbeGg55hIVz7X+I3M2so35rTUAeh1JPi0pFwjNGAtSKYXxF9AZno1Cv32J1KRdHPrtl+gMvoFe
+        TO/jVYrer/TojZMbhkLkSSeO+uvyTmMMPWD57JfSn5jycMRSPVuUhyPv/oyVx/2xOHgcMCSm4kSC
+        FzfOhj24te5MG8dYeCZ5vXBntmiMKv5ODcdo/TAftwolfuT4fA3IwJO2mcdozKHwbtY7sq/3gEbD
+        w1tSYshWh0hHGuQHPD5N+CYPMWpkTJc8wYOvXYPghHh3gqdbXnbSXx43OKdaY7/aI6VxO5uYZG6M
+        TuVYXSGVV3CFB2JznoRONB1yGlIMw7iJoUVooLPfEKj4H55dS/F0wqDtjoM0OgKsGUllUJ4pSzf/
+        WOOtwMKXxUVO+G8GBmNTCcXcng1MxzkFjrFoyTu9Cl6euUiq3h59i30/PQORCzsc4VUvKYeC3FXy
+        O/KGsQ/hDhc6B3eKe/jDngGbOlgnRTKooCYA/4eBx9G5Xsx+xD54sKaogqC8QbXwji6tZskyyObw
+        hvsn4nEqTopDshGvMaCgfjbAEl5C77N//v0foAYCPNUH1t6WZFIoHjSLn4Y0ZtX7IrXf7wvuKpVt
+        EIt7tKO7i5vxzDi61bFiYPaYygN7mPDEVWfvFsHjCjxz92GxFAuOqLJHDokqIyijKDPm33Ikhpcc
+        LY+p6xyFvbJiQJc4gzll46Ft3bjWdETK/aiA9eTdC3vlPNBs/Sbws/V/Yf1/CsJCr9WHQGasW2mv
+        yOxQ5olTysanGHVyQJk6nc+P4yIek2mpmucgdxNVLALFyhzsx+AKKMTvC95aW/tNoLvfbWpfBdt3
+        lmU/gTS0lQE0C6pVdgBWRFcsUe295Ae1AUj4jsB+3u60vwXYRwNoj99oT4SZ7F0gFvGKHdmZBKlQ
+        LlqaqW/AZvK9gb392wB7r6n1vwraoS229ePdM/wtFT3jZN/bOh4VV2+kgnj9O0K71rn4JmifmO5s
+        rhrH8TpoMqnpK0cje0Ogg4zvDepa8/y3AfXu10H63a1tq+fPYB0a0d1JG3lAu/jue0G73ml/E7Tj
+        WYiqt48j9oO4BRDqpQLv4kxKJdr3hnL9t0HoX0uZ/1+9/HI+v/5VfH79vSH9/3z+v8PnlUNbZ8O8
+        4L64HcBDnyf3pn5cd+eXR1HlprS11Zpar4n/0K4IwGIyUfHUsnpAK0Y8NpTiVNKI/Rf+SctNELJi
+        4NGbv1YuD2OWDYY3Kk4rnxULnYqIwVND/nNOtCWvELWmfvK0cqMIYcGnz7r1n538EQ/5/gVJ2x7y
+        eDUAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out,
+        CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+      CMR-Hits:
+      - '1'
+      CMR-Request-Id:
+      - 4fe34233-943e-478d-b868-67e374dd170c
+      CMR-Search-After:
+      - '[0.0,400.0,"GAMSSA_28km-ABOM-L4-GLOB-v01","1.0",2036881735,14]'
+      CMR-Took:
+      - '428'
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-MD5:
+      - d18ecd9d9bae18b7a2a20b3c47aa3eef
+      Content-SHA1:
+      - 06d318219fb8d95426a9fdbd5947d9efe55640c4
+      Content-Type:
+      - application/vnd.nasa.cmr.umm_results+json;version=1.18.4; charset=utf-8
+      Date:
+      - Wed, 25 Jun 2025 17:57:56 GMT
+      Server:
+      - ServerTokens ProductOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding, User-Agent
+      Via:
+      - 1.1 f1f259972a1922859cce8cd3da009a44.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - gw7SCUBH2pRdDLfFKpSPFb645ewgICl0lkW4vdQh494JYvsZyHw1Yw==
+      X-Amz-Cf-Pop:
+      - MSP50-P2
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - gw7SCUBH2pRdDLfFKpSPFb645ewgICl0lkW4vdQh494JYvsZyHw1Yw==
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_utils/test_calculate_request_size_no_resolution.yaml
+++ b/tests/cassettes/test_utils/test_calculate_request_size_no_resolution.yaml
@@ -1,0 +1,183 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - earthaccess v0.11.0
+      authorization:
+      - DUMMY
+    method: GET
+    uri: https://cmr.earthdata.nasa.gov/search/collections.umm_json?has_granules=true&include_granule_counts=true&concept_id%5B%5D=C2723754864-GES_DISC&page_size=2000
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAANVc63bbyJF+lT7cP1KWgEhKsmTt8dnAJEzRw1tISs5kPPGBgCaJGAQYNCBZ9vE7
+        5Rn2yfar6gYIUpQsT8abrI8smkBf6vpVdXW3v9SWYaZqF816LUuSj7WLk9NWvRZmcoWHv3yprWTm
+        1S6+1FJ5G6owia0wqF20GvVaICOZSXyZe5GS9do8SVdeVruoeet1FPpehsZHt3Fgx57ybH+V2vlq
+        9Z9/U0lcq9fWaXIbBjLl0Wpdd/qh05u28WLpKctPVjdhLMuRc1U09KNE4otpp2dUZTtPqcQPeWJF
+        JN96aejdRJIYqV0fN09fvDhttk6Prcp85ePj072Pm2d7H5809z5u7R/79Hz/2I9M+XI/gY39lDzC
+        Tmt/68rYv36t19SxFYXxR5aQOr44OlpIFYTKt/x8lUe5sqCogH5l0oeyj7rjwYf+MX8c9wbupNt5
+        YzfOjmq/ao2oNaTvRZbKb5TMsjBelMqJ8eZWGn1Xun9onBl1ZqkXK9LpXo1aAQwxjB4o9kvNT2Jf
+        rjM99F41f60/1qqq9cdbVY3g8VZVm3i8VetZdFUt5gm6nkf9y2dJovEsHp8n1dazxqrSRcZIRlBR
+        bZbmMIGtvu3WWev47PTk/MVJ1bxLbAq8DLBRazVap1bj1Go1Zo2Ti9MXF8cv7fOX539B0wWMLI8k
+        MCaPAVYvz18eG+uTq3WS7rfdgobsfk3D+0kUwR0wIbirAdXIJjte5vW9eJF7C2rjxosoVEvM6MR+
+        GEVeev+TvL9L0oB9zclWiVovZSrrYpxKP1yHGZt5XVzeB2kSJYt7cqp2OVXbNNA2306llyUpJrrM
+        5/OVh35d+61dF679xhbTLPE/yrQuOvbMFq+T6DaM6dVbWwxl9JG+vPX8j4BiMfMIjt0g1KM5cZDK
+        ezH1bjN/KeOPCV4SZ6BRyVhT8AYuiqadcAGSIjH1QwnxCGqG1qMYgCInUiV56kuSTB8Ao4WyzLK1
+        AsgQwtgLNfd1bFgkt0fQnLeR69EOQtjLbBWRsMf5DYlVEq3dJAi8NBCul2bLggzFdAgvDkQv1gEC
+        44mpTG9DetsGFzIVB7AeQdZzCJJnYRZJDUuC5xRvwhicbSlG9I9FUwTevWjY+JSLVErxqfrlmpEM
+        M4VSDb2V3AE6vJsgZHpKdkorPbYaZ1azNWs0LvjHbjQaZKXXMiV7RiMe0/QbR57Po2K2+EZGWV0M
+        OnAdTKpx1/2USbLqL2jCZm6eT+S6oj/yI2cyc6c9Z4jBL5M0/JzgXWRad5KVF8Y8ikwQ/tN7+nc7
+        ge1CLJmc3is4y84or+FPeL2YQIHwggKb30mVFa82I9QurOY5UohhAs3te/0SL11vf1fuOU3y/T2t
+        lw1gydevVdcZpwkUpBTZd3vWu3ZJTaCSrAfvgtzPSlc3ZlTxVbCOkRcJiaHmguVLMW333GGbhpkl
+        69CncWeD0XR86U74oWQHGU/cdm/cmzmz3mjIOPi7DATrMBjZl7cyau42EM5gdDWc/R9OOHFm7g+d
+        bjrq9zriyWYtajYcvfuhdPR7f7p6DiETpzdkv5yZoKIdU1vTBO7BEDALV8ZLXstFGMew5OIxxmi+
+        fHluNZr42UEHmDdGht0CzhT68KzkoT2KkMeEkp1Rj0MSfdSaDfu08eKMIPXIQNFRx/n5CMiCptMl
+        fHA/WrkxXP/3w0ZgbmX8Q+FlogDhmgF2vWiYyDniImE5C8eBp+tIl8SLuvgZQe4nW/Rtcanyupgi
+        2iVpkqhlSEGQcP/Ptuh6yfaYJeQ2TvYKdRMEthlzVRaaEDJPk5WYyBVS4QgRUsZKIsasENnSe3FF
+        msDswkmzcB4iZ40QavOUPzJAyUfRjpI8wG/ktNTCxCWNpUXYwPyI0Q4WULYYYHUFziIysCTKWUMn
+        x8QWpqSWzfPjE+DoaYttfiOmTUIgKCOY2AIpgRNEOiEQlYwALbo5JQaikhlAuGNqcseD/Aw5s9xd
+        HqbMLEjQGOy1Ld4l0Xz+mLTPviHt2VKK2WQwEIM8ykJLoWMUYfG5Y18OTO5ehepC/Cn3VGh1o+TG
+        i+qm18/SA0VtvWoMLFJNkoq9ikQGALuDCUskDF4k7R3Rc/K1YsnbVcGfHzQPK6I/PrdOT7fF/ja5
+        9yVLm4QOCf45lFpMGJYk7MXJXeh9fERSzeY3JPWTF0EhID2i/OW1R9bXHowm48tnstBsVW3n9ASJ
+        x+kLsqddtGg2z06P3l4OrI5FVLVadrP2dYvXSR5A6XVoX3N4BcPwl7GkFf1jlnD6Df7aXuTnkVZW
+        MhfdNAwCsLitRc7tkNWJDHajjUAg6YbO83SO5Mj4YS+2pmGWAwbyhRQj5PPprUmeK7IiCLVpLhqs
+        xQkjRIs0wjazkm2nH2nAbprka/6mlsm6KlUsNFrnYuRnyQ3UQvgCq0xoIHkPm3RUReit46bVOjnj
+        yAA7hp3fGxf4u/6miQkVUDPFYjkApIbAmrXOUQReqHAVYi0hsoSp3uonhc65BeXScO4N2l5eQkEh
+        Jek8On6o9fsaQ/n7mpDGOYpxPJ+X/3gSYPKqAgrZA+vrImSSbtBb5GSOd1gxiGW4WNITGiP1/HvB
+        7KgwlYE2FuoOFhb0G1ERLQ5aYgWRLdWh8GHiNyAzAVrR9GTBvemIo7aJ6qGu57T7vYEzG/VH3Z+P
+        Bu7MHU30vyuBHWLuYF4/64QqS8ObnFiorArI6icIvZwS58q6A90Wecn0GOurABEbMK6ccc+Ng3US
+        Uma9WcJAxrYpltiSViD8pFzPqGN/M8SeITsJRFxk5FeT/m8deuI6nQEntMevc0BzhhXc6OZvYBo2
+        PA8/UWj/56s7SBQcn/KNNnwoS7E8yLgQ05HKT8O1WVUMk1hSToHlCunuKo10BN9u1WGbdiomth+p
+        xQGb56EOvJv84+CRHONwJ8GATHbkmvgEBDLdCDehz41k1wxcRxAICZAzpps0uVPywXp0HS/0+G3y
+        9Tib6crAdajIIz+XWgW+6TdddyYmbh+Zckdc96ZXTr/3l83CYFtCWtTGzzIgfQZX4ZWOWANKtEAY
+        AU3+JO7kjULUtB/y/NtW2iXZHWfmiClo7zvDTm/YFWOn6+7jfLPaIgK+yZO4DT1xOZuNpw9IXqxX
+        zUc1RH0fNVM4QX6TVQifTVx3WwX0eB/5VYR4PgP0ZTSWw44zJpBGbsTp2nfwk6wllqHrx1jyNZGq
+        0MqGv9HY5WkNQ4aNq6kLbU2ue21XAGR+G6cUkLqp05nqcDtln4FzdaaHBObIY8B3SqFgRQGjEEC2
+        RGZl6voIVGUVjUFfISPBP3QWJ1RRjfH8NDFC1cFXZg9t+GmDSAL1wIZDYPyWtLoTZkcb8+TanWh2
+        fmfBPWYis8uJ2+lMv5OzbAmUB3NIpLwoWRx5C6DcwnvgtGwnus1DMzFT/wgzuVKSuXOLCAVL8VJ/
+        SbnJPITOSe+pxChYoGqBwCJKna8odV9H5o3PZTn1UESKx9wbBvnNf//91cPdhA3/u8T9Xmgw0+hr
+        Mfqy6Xo+7W8IXf4UW4FAOENIY2iMn1tzsnrQDZNbDwt/7VeE4tYNJ/ZZkkTaobwoQgCi/CpVJFn2
+        oc9SLEx+zLyFGwIQWhNNwl2IbD3PxNK7JS9E3yC5i6PEI83cc8c9Fmko2okZ/0GtTU3s1aZCUHGw
+        3ujaGQ57zwl4z4mbJPFtykiReQqO7PVaPXCWIp1SusTx4bpx9sGZve58mFMOYa+D+Ra5Tr87mvRm
+        lwP4JjJHd9ZrO33x2pn24Cqj9tXAHc7EAQ1QwYjrnvuuZKk3fDOaDB5lqLIE2m9AOpeZSSyb0C4S
+        W/ngA7V8H/PlqFuDPiKKca/kuODmx/FrVj3wgUB++n0SNB74uvHiw596/yre2t6t9IBstDjSfEqu
+        95HrwzUTXeGAh/7OHNOwGNXy9fz/Kvb1EqS04N+e0EEaR3owG08esEOvrIH7Qw3U7LSIIZZEah8n
+        G8pTs8WliG7jf+FKpgvrtnFmpXogKzYDbdjoDcajycwBwAxHwJ0fxQ8tmCgCr4EdMdI1xVUxTt9W
+        yBVyJRCWaRm3h0kEohZ/3Qs3GX09cl6z9VLzD+WYDxMQZzgaAPrd6Q9kc6ydQ1xSkknFlicVtyFk
+        PBm9ddszcTmC+T5zYfOr3g+lupZZ3G5v5u2rcJmBYL9mn+TZfa7GHe6DWZ0bWnjTTlXtfWz2B0Xj
+        rCjm+Hmagmhxa96YSk6RdtliFAWwAvNaITuIIhEnIkriBZ7fIDu/xcKctjHYbJA1SDyVMTL5NTpJ
+        SjZu7sVmZvt9/D6emcx9wdWanSquC3fi9M+LNDiSsg7Y0Q4NUHLeM3SmTlnkMrUoSlkWusCnTG1v
+        uxKVFsVcj0tOgtwxyovyYcNu/s8/yMLTe7ASzS3ETuLS7LNQoa5hC9HjCha5SCGwv1Gdhymy3jp/
+        dooi43aJYgDXzlNJPs9Fh0OxCpXi3fucC5C8OAez7STd1B8T0LIpcHtab8rsQ1J+Zs497TCaVMqX
+        eunvxTrji/khqPOpKoNxy+ppOY0yBHkB0jqfMkvODf6eS0Xssw5MzY1LeKQlLXZLUX1cVA5zKaL5
+        DuPSZ0JrwpSLZ4pTTaEgRiAnBoBZAf54S6xUXpULzEx2MydezYkhXRk0u2U7utRUsiWbbBiCW5HA
+        brZLlaYoqgkvSpkb+pm5MPZTyTm2+ggXKIWwZH1QTWmSFxzdeuk9CU/XKUMIM4yJtjV4kJyMwwrh
+        PjRXdZ5YykBd4N06DKyy/ZYkD7AwQaqOuerixFoWpdDDOlS3kkcxEgiL9tO2O/WpLMZ9mtudGOgT
+        lWE2aA4OJIlOvRzTZTTd7dg+tbjUWvaFAN4tQ8hLi4HWPbdSeytZFRZCXKKlCYqKbr1ixbLcVoEM
+        tu3Wg+nLT2uuLJKwGFGgPopFJHptQjDozwwybCaqTk6AVeEnGENKdUbNm594is6afE5iNlxHG2Jd
+        Q98SSuAqPTxuQ9qOU9BkLJgVxAr3YbiBVmi/DrCqzHJrPqdIorI8CFkMvvYfjMALVuseQtUzghCN
+        gFTgNmU6A8ZECG/LimMjV/EH1sIfhK5+imZDfKJfH1e726JF6b8s8pXwhX6bplTSZy8q2kPfIBAf
+        5qiHpkTrfre+r7cVVhKO/xBUychXKyRm97aeYMObxmgdCOZhqjLWVp4VkPfEiAcYkpg4pC8al2kJ
+        i4U/qdHsC8RFVeC+GNFwhflaJ8wwqFiFcbgKP0vNIcxehYQ0AYa8CT120jLM3cg5QfD7WuPsfa1O
+        rxghwpWuPJAYsiSj+KRNHtQo2sdAn0jXcsDRyfmWErYAmawc8S0MqlsjWnCwPNqqy2M65wq3hieD
+        KzDA3KfU09BjgD8Aa36a3Hl0TjKeUwtTRYEjiAVvZhXqqIvipByY2xI58an9db2GsbI8eFMmJYpC
+        WDa50GyZK5bHKiE1YsiiyAAbMYH3wcAahE3qkNHfkFyIqgnh3Gza21pJfpKmOm2qiyWc/pY2jfFc
+        92G6DfNEm1VsZJUCKCpHtMtb4XTw7gGvWls0UuLrLMhnQ9/Sn1ZRVYusEDCN5IZPLhR6gS6AkFqD
+        fEhQFV7z7TEY4rzozrtXOncy5dCAIiblYQiR5A8FQ9rwS7Fre9QyJp4QtENdDUKKAsqihMJIViwt
+        OdwBs0rxmMFoX46yCbOhKo2JsT52vFPPyKkU7e0TGMJEdfAziV7hOsXOYQAIJtWZfM0QUvjkxh2R
+        EXGSggnNwcVqTrolX/IEIBSsqpSXsQ29k3mTZ/TtnhsmMSheAPJ4Xu0U2qcXMZ+rMOrf4ByzVzfl
+        SI4KKSWaFSAwEBDOuU6dcPFMLaXSRTM8tEWR7BZ7lsUMBn234b3IZQNJ5X1F0UM3jkK2MdNZh4ai
+        6yUZ1qU2rGIAwvsS7osd3BJZSBxmTC0yT9x4mb+sCzqvylapg30BTWQ46MMP61rN+ZqYPDEbsAV7
+        CPGJ9vObckZmuxhJxxXmti7WEVaT3g0VG1sngnyjBBhpL2zuQE1Dk1i89eIcqZUoMs9qlqBBi1JI
+        fKBHql3YWadhJFpaD4UuKmGM3epAh61DUdlB/85ItRWmvE2IqqA7vJN3v58fs0gQ1H8n7MHJNWLs
+        /CH2xszbByaT/rwS06vBl3Eo/iCav+CDsejXr+JImJY+liJ42ToByr76pVkfzn+lcd4ROF6U41Er
+        PVR1FJ4w3CbC2gK6MIbs6mUcTw/fx8P5bodhvqIzEDDuatd5WEHIuhjOX52cv4+bv9i/bvfuxQEl
+        uhDTPI8ZV/5LNPWRAtBG6EzE1kVD8PYTHFRusfWACA3X6WYFuqNRQxIncd3iqTbQu2WIxHkz+KtG
+        XYOUzPTuBrpjyLyMYdrtmVWMR8UjDc3j8FVDr3E1NdzJriiYKKeR9wGfEZ2nSoRXuyGZ+iMskyk+
+        iI36Xd2k8qleh9AmMuU85AJlrtGbWBpHaZzNY0bajfwYsv8dMJgiY6qDKJWxONpuZsKygRnOo4Cx
+        xaS+lYTanJKpGimWcQHe6r4HlXxDv3Dp+fvaYZEQb+Z5Qm+UBBUh2KDz3FNLgpqdUzxPpuM2sBb4
+        Vd/AVnHYBzkT4X6Vjx2CRTUpZYIYBKsncTRYEXTBs//aIt/WDWOAlcFk/YaQ1dbAT6Cvpxdpkuhl
+        j/fRWIPMqihoIIM6X7DdQ24fNMOvxBeGInHAD8PDv7Y0vPE3A07iUBDKDWHMH/BcY9zXvzbs0yrQ
+        bV5reDt4OAxNflegIb96n73P9sLcjhTrG9DbUE9dBx7MnfLpbVtny6iXbG+o0xPuItSmPKVNqlxS
+        E8XOgtfArO+ct9sLte+q2sTSincVatbb9ZuVumlZRMhNxWpTATSJ2V504wN+KfK84vzmg/rftFyD
+        P1H/8yI6y5UtV8UBsUWsrS2iMOkZRPlGnWvLXbjmfusBUSvlL0qE6a4MuONaJwsoDahzDqxK0hXB
+        YbiSR2pNdapiX3XbETfCKxyKlkhS48EWJ1wxQH904nkL2fIpuXIdjtAgPdoqp4IEWFrX2bV1Y7zU
+        J+tojeWJdqT78GGMCVMPvUa0ubtYaiEFEsIJOVQsk1WykDEBo1fwisdFWk47vv1EF5Qeu+PQdUfd
+        iTO+7LXFxO1u7Rt1+6PXTn/3jP03O/Dpoe/vNWq7jj5HP8AaInik7N6yGidW6/Q7y+7N1r57N7Ni
+        p4n2KPaV6h/vUynV79zeMdsTmu6d8/asjnhRPPhGsZlHv1LyyVN4s+JMhik8k1HpY+aPXI3S7w7c
+        0bTTmx7qEEbLSC68FVQs8jDgsE4OwAV7fW5DY4nHJ19onZuJYs9lz5ENGS/g2Hzoia7qeVZxEMhS
+        yTy7A65Z6yQKqdTKG4MWyLCKmRF7uH67oRw/y+SOl8cpxiQE97m0zsXKj3FyF8lgUQTlIvwz8cXJ
+        uTp8ZC45En/jyBzTIelkhbJrfL0ozjw/Q0RQxaW8SWLuGvcQPOHqC76iB5VxBC907I4mvNPU98pn
+        l1dv3gz4GpUZdeeQqhMEdH/JmP40S6XMqs9qmidzH27KQPYmChfLzNx3w8gDujybJWvxotnim4X6
+        9HF5l0zficrkmDKamO+ZDTpkvQlVXttJoN3g7KzJZOYx3wurXU0dtkpD+EBSbTRU5vK48Y0ZgHm9
+        pNOhdFkGKTAdoW80rRfNE+vFceOcPc20feN92tPq9ORlq9rKXYGdSruuTNKFtN/a5vbDH8vdProN
+        Vq/opoASYU6z76gHQDVxf95Wz9S5nrUv3eFPo9+uofJIEZzE0UeFnNRf0qe5kjiTlKOjERDgoX8q
+        0ccKO+VdJKYCWceLZsOm48rf1P6/kbpPzxqnTylSX0C1NxdQtzVptl81Xzte50zal71rd0LsVmGW
+        xHPUnb5pH03dzpE77RzNetP+ESDA3D2qIvA/c6eUXjEKFaN0HKd9WP8OzdYfTBzqm8318potUeF+
+        WkfUg69E8Al3+ibrTxlBnYHvUQPePbP98ExcKfatc807e+dPHz2myybbJ8arWCze6VPM+jK4IZNv
+        XuwomrVhhG6akc65aYmyZsxLtz8WHXf6E5YFYzp4IbqT0dX4tzvyP2Eh/6/9ttU6eQZMt16cP+Xd
+        ZA5WEFlLGa0tMpA/UgN728X5eiOs0fxXEBv6zOkCfb2ruBJW23Z2Xl1s+/R3nU+g+ya8flqVFza3
+        sGQ0E8543O+1ndd9l0W8oqVQMJo/aLuXXMH3N6s57XSNbK+4EEgmuO1GfhDvO/2aY3VZOcV/27Sb
+        5/YJGZWe/GowsPh//ihzUdOCrnLowAOofeJizBss90zDrTd0I1Mv0KjFNPxMV7Jb9d2HV1gZkwxe
+        g4Y3xf8ME8uszQdH9ROj1iH/zyCse/z9X8J6qKmQRgAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out,
+        CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+      CMR-Hits:
+      - '1'
+      CMR-Request-Id:
+      - ca805623-9bfc-47fa-a00a-fa92e2e5053c
+      CMR-Search-After:
+      - '[0.0,3200.0,"GPM_3IMERGDF","7",2723754864,20]'
+      CMR-Took:
+      - '453'
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-MD5:
+      - ee5eeae37eaca536a8ca99d52c5e7f98
+      Content-SHA1:
+      - 04404d0331b27687543997c956659a68ec045470
+      Content-Type:
+      - application/vnd.nasa.cmr.umm_results+json;version=1.18.4; charset=utf-8
+      Date:
+      - Wed, 25 Jun 2025 17:57:56 GMT
+      Server:
+      - ServerTokens ProductOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding, User-Agent
+      Via:
+      - 1.1 a5e934660f9817baef055c1ec689c0b6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - PykePVjn6U4vl5GXB-P-VN7SPBtI2h5n336TjfIljn_PTrI__aoc5w==
+      X-Amz-Cf-Pop:
+      - MSP50-P2
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - PykePVjn6U4vl5GXB-P-VN7SPBtI2h5n336TjfIljn_PTrI__aoc5w==
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,38 @@
+"""Tests for utils.py"""
+
+import pytest
+
+from titiler.cmr.utils import calculate_time_series_request_size
+
+
+@pytest.mark.vcr
+def test_calculate_request_size_no_resolution() -> None:
+    """If a concept_id does not include the horizontal resolution in the UMM metadata
+    it should return 0"""
+    request_size = calculate_time_series_request_size(
+        concept_id="C2723754864-GES_DISC",
+        n_time_steps=2,
+        minx=-180,
+        miny=-90,
+        maxx=180,
+        maxy=90,
+        coord_crs="epsg:4326",
+    )
+
+    assert request_size == 0
+
+
+@pytest.mark.vcr
+def test_calculate_request_size() -> None:
+    """A concept_id that DOES include the horizontal resolution will return a positive value"""
+    request_size = calculate_time_series_request_size(
+        concept_id="C2036881735-POCLOUD",
+        n_time_steps=2,
+        minx=-180,
+        miny=-90,
+        maxx=180,
+        maxy=90,
+        coord_crs="epsg:4326",
+    )
+
+    assert 0 < request_size < 1e10

--- a/titiler/cmr/utils.py
+++ b/titiler/cmr/utils.py
@@ -80,7 +80,7 @@ def parse_datetime(
     return datetime_, start, end
 
 
-def get_resolution_degrees(concept_id: str) -> Tuple[float, float]:
+def get_resolution_degrees(concept_id: str) -> Tuple[Optional[float], Optional[float]]:
     """Query CMR to get the resolution of a dataset using its concept_id. If the units are in meters
     convert to degrees using the rough conversion factor of 0.00001 degrees per meter"""
     ds = earthaccess.collection_query().concept_id(concept_id).get()[0]
@@ -93,7 +93,7 @@ def get_resolution_degrees(concept_id: str) -> Tuple[float, float]:
         logger.warning(
             f"could not find HorizontalDataResolution for concept_id {concept_id}"
         )
-        return (0, 0)
+        return (None, None)
 
     units = resolution_info["Unit"].lower()
     if units not in ["meters", "decimal degrees"]:
@@ -135,7 +135,7 @@ def calculate_time_series_request_size(
     as a total number of pixels read across the entire time series
     """
     xres, yres = get_resolution_degrees(concept_id)
-    if (xres == 0) and (yres == 0):
+    if not (xres and yres):
         return 0
 
     minx, miny, maxx, maxy = get_bbox_degrees(minx, miny, maxx, maxy, coord_crs)

--- a/titiler/cmr/utils.py
+++ b/titiler/cmr/utils.py
@@ -4,6 +4,7 @@ Code from titiler.pgstac, MIT License.
 
 """
 
+import logging
 import time
 from datetime import datetime
 from typing import Any, List, Optional, Sequence, Tuple, Type, Union
@@ -17,6 +18,8 @@ from rasterio.warp import transform_bounds
 from rio_tiler.constants import WGS84_CRS
 
 from titiler.cmr.errors import InvalidDatetime
+
+logger = logging.getLogger(__name__)
 
 
 def retry(
@@ -81,9 +84,17 @@ def get_resolution_degrees(concept_id: str) -> Tuple[float, float]:
     """Query CMR to get the resolution of a dataset using its concept_id. If the units are in meters
     convert to degrees using the rough conversion factor of 0.00001 degrees per meter"""
     ds = earthaccess.collection_query().concept_id(concept_id).get()[0]
-    resolution_info = ds["umm"]["SpatialExtent"]["HorizontalSpatialDomain"][
-        "ResolutionAndCoordinateSystem"
-    ]["HorizontalDataResolution"]["GenericResolutions"][0]
+
+    try:
+        resolution_info = ds["umm"]["SpatialExtent"]["HorizontalSpatialDomain"][
+            "ResolutionAndCoordinateSystem"
+        ]["HorizontalDataResolution"]["GenericResolutions"][0]
+    except KeyError:
+        logger.warning(
+            f"could not find HorizontalDataResolution for concept_id {concept_id}"
+        )
+        return (0, 0)
+
     units = resolution_info["Unit"].lower()
     if units not in ["meters", "decimal degrees"]:
         raise ValueError(
@@ -124,6 +135,9 @@ def calculate_time_series_request_size(
     as a total number of pixels read across the entire time series
     """
     xres, yres = get_resolution_degrees(concept_id)
+    if (xres == 0) and (yres == 0):
+        return 0
+
     minx, miny, maxx, maxy = get_bbox_degrees(minx, miny, maxx, maxy, coord_crs)
 
     n_pixels_per_request = (maxx - minx) / xres * (maxy - miny) / yres


### PR DESCRIPTION
There are concept_ids which are missing the `HorizontalDataResolution` attribute so we cannot calculate the array size from collection-level metadata alone. This change will allow any time series request for a dataset that does not include this piece of information to proceed regardless of request size.

resolves #59 