### PR TITLE
feat: add /concept_metadata and /compatibility endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-- Nothing
+### Added
+
+- interpolate {datetime} in if sel includes {dim}={datetime} ([#78](https://github.com/developmentseed/titiler-cmr/pull/78))
+- /compatibility and /concept_metadata endpoints ([#80](https://github.com/developmentseed/titiler-cmr/pull/80))
 
 ## [v0.2.0]
 

--- a/tests/cassettes/test_backend/test_get_assets[direct-s3].yaml
+++ b/tests/cassettes/test_backend/test_get_assets[direct-s3].yaml
@@ -46,8 +46,6 @@ interactions:
       - ServerTokens ProductOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
       Vary:
       - Accept-Encoding, User-Agent
       Via:
@@ -159,8 +157,6 @@ interactions:
       - ServerTokens ProductOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
       Vary:
       - Accept-Encoding, User-Agent
       Via:
@@ -179,6 +175,305 @@ interactions:
       - 98HS8BTg1uH0rmuHEjWnzfBYUluUM9VT_Z9901kSgQo9d4dPsQK-dg==
       X-XSS-Protection:
       - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - earthaccess v0.11.0
+      authorization:
+      - DUMMY
+    method: POST
+    uri: https://urs.earthdata.nasa.gov/api/users/find_or_create_token
+  response:
+    body:
+      string: '{"access_token":"eyJ0eXAiOiJKV1QiLCJvcmlnaW4iOiJFYXJ0aGRhdGEgTG9naW4iLCJzaWciOiJlZGxqd3RwdWJrZXlfb3BzIiwiYWxnIjoiUlMyNTYifQ.eyJ0eXBlIjoiVXNlciIsInVpZCI6ImhlbnJ5ZGV2c2VlZCIsImV4cCI6MTc2MTAwNDc5OSwiaWF0IjoxNzU1Nzk4ODI5LCJpc3MiOiJodHRwczovL3Vycy5lYXJ0aGRhdGEubmFzYS5nb3YiLCJpZGVudGl0eV9wcm92aWRlciI6ImVkbF9vcHMiLCJhY3IiOiJlZGwiLCJhc3N1cmFuY2VfbGV2ZWwiOjN9.S8pLKlQhsVOVXEDg576dgrS2fa9Lb-6UZOPedp5q4xrckbSNtk9ISLnongxlBpeGzJ0FbRSJZW3FNr2SYMttJjQPqTpCqtJ0_kEdk9UFDsTOCIAqrULZQXosEhSl7eq15pvFVxY1pdm8FbssHB0hWrjSnZTYZ3hm_Hl_-VyEYMz8kqMRBejviLL7vk1NcS3e0yG2qjBKKAUU_CCkb_fVTh92yvgBHd7LYlfJSDyCU_iP2TWk3SJ05mvvbvyaQYPTZMA4Y4tZ_LhpG3A7Sfh4IVz6VxqNrjvET68QJ_hwdJdXEVIYos4L4NmBh2ShbsFxyVrWrKE9iP2VpafPSxS1bQ","token_type":"Bearer","expiration_date":"10/20/2025"}'
+    headers:
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 10 Oct 2025 11:34:24 GMT
+      ETag:
+      - W/"6e5ffdbcf7810da2895c35430e47c80b"
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx/1.22.1
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 7f00dfbc-ca5a-4089-9025-80bbad0a2175
+      X-Runtime:
+      - '0.060532'
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - earthaccess v0.11.0
+      authorization:
+      - DUMMY
+    method: GET
+    uri: https://urs.earthdata.nasa.gov/profile
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 10 Oct 2025 11:34:24 GMT
+      Location:
+      - https://urs.earthdata.nasa.gov/home
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx/1.22.1
+      Set-Cookie:
+      - _urs-gui_session=80b0d983431a3880d4f748f75f3447a4; path=/; expires=Sat, 11
+        Oct 2025 11:34:24 GMT; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - d0320259-5872-4928-a5c9-717683b4ca34
+      X-Runtime:
+      - '0.005162'
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 302
+      message: Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - _urs-gui_session=80b0d983431a3880d4f748f75f3447a4
+      User-Agent:
+      - earthaccess v0.11.0
+      authorization:
+      - DUMMY
+    method: GET
+    uri: https://urs.earthdata.nasa.gov/home
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<!--[if lt IE 7]><html class=\"no-js lt-ie9 lt-ie8
+        lt-ie7\"> <![endif]-->\n<!--[if IE 7]><html class=\"no-js lt-ie9 lt-ie8\">
+        <![endif]-->\n<!--[if IE 8]><html class=\"no-js lt-ie9\"> <![endif]-->\n<!--[if
+        gt IE 8]><!--><html lang=\"en\" class=\"no-js\"><!--<![endif]-->\n  <head>\n
+        \   <meta charset=\"utf-8\">\n    <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge,chrome=1\">\n
+        \   <title>Earthdata Login</title>\n    <meta name=\"description\" content=\"Earthdata
+        Login\">\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n\n
+        \   <!-- Google Tag Manager -->\n    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(\n\n
+        \     {'gtm.start': new Date().getTime(),event:'gtm.js'}\n\n    );var f=d.getElementsByTagName(s)[0],\n
+        \     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=\n
+        \     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);\n
+        \   })(window,document,'script','dataLayer','GTM-WNP7MLF');</script>\n    <!--
+        End Google Tag Manager -->\n\n    <link href=\"https://cdn.earthdata.nasa.gov/eui/1.1.3/stylesheets/application.css\"
+        rel=\"stylesheet\" />\n    <link rel=\"stylesheet\" href=\"/assets/application-f6bf1b938c8159947246866978e15c467902bef70b069dabf6fee52c2d02f034.css\"
+        media=\"all\" />\n    <!--[if IE 7]>\n      <link rel=\"stylesheet\" href=\"/assets/font-awesome-ie7.min.css\">\n
+        \   <![endif]-->\n    <link href=\"//netdna.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css\"
+        rel=\"stylesheet\">\n    <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,700'
+        rel='stylesheet' type='text/css'>\n    <meta name=\"csrf-param\" content=\"authenticity_token\"
+        />\n<meta name=\"csrf-token\" content=\"rI5Vn586GifCKWF_d940WsLrrsd_DVXCMBqqmTzUBrI9Zd0Vv5ZLPHCeI55LsrsJ789YiyriIeqV_0LF4_X3_g\"
+        />\n    \n\n    <!-- Grid background: http://subtlepatterns.com/graphy/ -->\n
+        \ </head>\n  <body class=\"static_pages home\" data-turbolinks-eval=false>\n\n
+        \   <!-- Google Tag Manager (noscript) -->\n    <noscript>\n      <iframe
+        src=\"https://www.googletagmanager.com/ns.html?id=GTM-WNP7MLF\"\n                    height=\"0\"
+        width=\"0\" style=\"display:none;visibility:hidden\"></iframe>\n    </noscript>\n
+        \   <!-- End Google Tag Manager (noscript) -->\n\n      <div id=\"tophat3\"></div>\n
+        \   <!-- Add the Status banner -->\n      <div id=\"earthdata-notification-banner\"></div>\n
+        \   <!-- End Status banner -->\n\n    <!--[if lt IE 7]>\n      <p class=\"chromeframe\">You
+        are using an <strong>outdated</strong> browser. Please <a href=\"http://browsehappy.com/\">upgrade
+        your browser</a> or <a href=\"http://www.google.com/chromeframe/?redirect=true\">activate
+        Google Chrome Frame</a> to improve your experience.</p>\n    <![endif]-->\n\n
+        \   <div class=\"container\">\n          <div class=\"eui-banner--danger\">\n
+        \     You must be logged in to access this page\n    </div>\n\n\n\n\n\n\n\n\n
+        \     <section id=\"callout-login\">\n  <form id=\"login\" action=\"/login\"
+        accept-charset=\"UTF-8\" method=\"post\"><input type=\"hidden\" name=\"authenticity_token\"
+        value=\"JbtA9NTNtd3-dE_5Y5Jg8t3gTuScljx2RKXVwbCZeI60UMh-9GHkxkzDDRhf_u-h8MS4qMl5SF7hQD2db7iJwg\"
+        autocomplete=\"off\" />\n  <p>\n    <label for=\"username\">Username</label>\n
+        \   <i class=\"fa fa-question-circle fa-question-circle--blue user-name\"
+        title=\"Login using either your Username or Email Address\"></i>\n    <input
+        type=\"text\" name=\"username\" id=\"username\" autofocus=\"autofocus\" class=\"default\"
+        />\n  </p>\n  <p>\n    <label for=\"password\">Password</label><br />\n    <input
+        type=\"password\" name=\"password\" id=\"password\" autocomplete=\"off\" class=\"password\"
+        />\n    <span class=\"password-showhide hide-password\">\n  </p>\n  <p>\n
+        \   <input type=\"hidden\" name=\"client_id\" id=\"client_id\" autocomplete=\"off\"
+        />\n  </p>\n  <p>\n    <input type=\"hidden\" name=\"redirect_uri\" id=\"redirect_uri\"
+        autocomplete=\"off\" />\n  </p>\n  \n  <br/>\n  <p class=\"button-with-notes\">\n
+        \   <input type=\"submit\" name=\"commit\" value=\"Log in\" class=\"eui-btn--round
+        eui-btn--green\" data-disable-with=\"Log in\" />\n    <!--%= link_to \"Register\",
+        new_user_path(app_user_register_params), class: \"eui-btn--round eui-btn--blue\",
+        id: \"register_new_account_button\" %-->\n  </p>\n  <p class=\"form-instructions\">\n
+        \     <div class=\"row\">\n        <div class=\"col black-text\">\n          <em
+        class=\"icon-question-sign link-color\"></em>\n          Need Help?\n        </div>\n
+        \       <br/>\n        <br/>\n        </div>\n        <div class=\"row user-options\">\n
+        \         <div class=\"col user-options\">\n            &#x2022; <a href=\"/retrieve_info\">Forgot
+        Username</a>\n          </div>\n          <div class=\"col user-options\">\n
+        \           &#x2022; <a href=\"/reset_passwords/new\">Forgot Password</a>\n
+        \         </div>\n        </div>\n    </p>\n</form>\n<aside class=\"govt-msg\">\n
+        \ <p>\n    <strong>Why must I register?</strong>\n  </p>\n  <p>\n    The Earthdata
+        Login provides a single mechanism for user registration and profile management
+        for all EOSDIS system components (DAACs, Tools, Services).\n    Your Earthdata
+        login also helps the EOSDIS program better understand the usage of EOSDIS
+        services to improve user experience through customization of tools and improvement
+        of services.\n    EOSDIS data are openly available to all and free of charge
+        except where governed by international agreements.\n  </p>\n    <br/>\n    <div
+        class=\"idfs-button-alignment\">\n          <a class=\"eui-btn--round eui-btn--blue\"
+        href=\"/users/new\">Register for a Profile</a>\n    <div>\n</aside>\n\n</section>\n<div
+        class=\"home-info-box\">\n  <hr class=\"home-divider\">\n  <br />\n  By clicking
+        the Log In button above, you are acknowledging that all Earthdata Login applications
+        running in <a\n    href=\"https://earthdata.nasa.gov/about/daacs\">DAACs</a>\n
+        \ will have access to my profile information.\n</div>\n    </div>\n    <footer
+        role=\"contentinfo\">\n  <div class=\"govt-warning\">\n  <div class=\"warning-desktop\">\n
+        \   <p>\n        Protection and maintenance of user profile information is
+        described in\n        <a href=\"https://www.nasa.gov/about/highlights/HP_Privacy.html\"
+        class=\"ext\" target=\"_blank\">NASA's Web Privacy Policy</a>\n    </p>\n
+        \ </div>\n  <div class=\"warning-mobile\">\n    <p>\n        Protection and
+        maintenance of user profile information is described in\n            <a href=\"https://www.nasa.gov/about/highlights/HP_Privacy.html\"
+        class=\"ext\" target=\"_blank\">NASA's Web Privacy Policy</a>\n    </p>\n
+        \ </div>\n  <div class=\"warning-mobile-mini\">\n      US Govt Property. Unauthorized
+        use subject to prosecution. Use subject to monitoring per\n      <a href=\"https://nodis3.gsfc.nasa.gov/displayDir.cfm?t=NPD&c=2810&s=1E\"
+        class=\"ext\" target=\"_blank\">NPD2810</a>.\n  </div>\n</div>\n\n    <p>For
+        questions regarding the EOSDIS Earthdata Login, please contact <a href=\"javascript:feedback.showForm();\"\n
+        \       title=\"Earthdata Support form\">Earthdata Support</a></p>\n    <br
+        />\n    <ul>\n      <li>\n        <b>V 4.231.0\n</b>\n      </li>\n      <li>\n
+        \       <a href=\"/\">Home</a>\n      </li>\n      <li><a title=\"NASA Home\"
+        href=\"http://www.nasa.gov\">NASA</a></li>\n      <li><a title=\"Accessibility\"
+        href=\"https://www.nasa.gov/accessibility/\">Accessibility</a></li>\n    </ul>\n
+        \   <p>NASA Official: Doug Newman</p>\n</footer>\n    <script src=\"/assets/application-adccbf210b74fe4a7d457a0c2eb3fbd9f99407c4393065d95646d13d0451251f.js\"></script>\n
+        \   <script type=\"text/javascript\">\n    $(window).scroll(function(e){\n
+        \     parallax();\n    });\n    function parallax(){\n      var scrolled =
+        $(window).scrollTop();\n      $('#content').css('background-position', 'right
+        ' + -(scrolled*0.25)+'px ');\n    }\n    </script>\n\n\n      <!-- Set js
+        variables for tophat3 _config.js  -->\n      <script>\n        const th3Script
+        = document.createElement(\"script\");\n      </script>\n\n      <script>\n
+        \       document.addEventListener(\"DOMContentLoaded\", function() {\n  th3Script.setAttribute(\"src\",
+        `https://cdn.earthdata.nasa.gov/tophat3/Tophat3Widget.js`)\n  th3Script.onload
+        = ()=> {\n    const tophat3Config = {\n      appTitle: \"LOGIN\",\n      menuData:
+        [ { title: \"Documentation\", url: \"/documentation\" },\n ],\n      showStatus:
+        true,\n      statusNotificationUrl: `https://status.earthdata.nasa.gov/api/v1/notifications`\n
+        \   }\n    Tophat3(tophat3Config);\n  }\n  document.body.append(th3Script);\n})\n
+        \     </script>\n\n    <script type=\"text/javascript\" src=\"https://fbm.earthdata.nasa.gov/for/URS4/feedback.js\"></script>\n
+        \   <script type=\"text/javascript\">\n      feedback.init();\n    </script>\n
+        \   <script type=\"text/javascript\">\n        setTimeout(function()\n                {var
+        a=document.createElement(\"script\"); var b=document.getElementsByTagName(\"script\")[0];\n
+        \                   a.src=document.location.protocol+\"//dnn506yrbagrg.cloudfront.net/pages/scripts/0013/2090.js?\"+Math.floor(new
+        Date().getTime()/3600000);\n                    a.async=true;a.type=\"text/javascript\";b.parentNode.insertBefore(a,b)}\n
+        \               , 1);\n    </script>\n\n    <!-- BEGIN: DAP Google Analytics
+        \ -->\n    <script language=\"javascript\" id=\"_fed_an_ua_tag\" src=\"https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NASA&subagency=GSFC&dclink=true\"></script>\n
+        \   <!-- END: DAP Google Analytics  -->\n    <script src=\"https://status.earthdata.nasa.gov/assets/banner_widget.js\"></script>\n
+        \   \n  </body>\n</html>\n<script id=\"f5_cspm\">(function(){var f5_cspm={f5_p:'PLPIDEFCJHCKOIBMFMHKBFMBAPIEPOCKOJADAFFJCMIICBCBPDHDLIJNKHDDHFHOICKBGABBAAMNBAJOAPNAEFGPAAJKFEFBGFCGFCKGCMOENBAFDIFBNGONGGPNLHBL',setCharAt:function(str,index,chr){if(index>str.length-1)return
+        str;return str.substr(0,index)+chr+str.substr(index+1);},get_byte:function(str,i){var
+        s=(i/16)|0;i=(i&15);s=s*32;return((str.charCodeAt(i+16+s)-65)<<4)|(str.charCodeAt(i+s)-65);},set_byte:function(str,i,b){var
+        s=(i/16)|0;i=(i&15);s=s*32;str=f5_cspm.setCharAt(str,(i+16+s),String.fromCharCode((b>>4)+65));str=f5_cspm.setCharAt(str,(i+s),String.fromCharCode((b&15)+65));return
+        str;},set_latency:function(str,latency){latency=latency&0xffff;str=f5_cspm.set_byte(str,40,(latency>>8));str=f5_cspm.set_byte(str,41,(latency&0xff));str=f5_cspm.set_byte(str,35,2);return
+        str;},wait_perf_data:function(){try{var wp=window.performance.timing;if(wp.loadEventEnd>0){var
+        res=wp.loadEventEnd-wp.navigationStart;if(res<60001){var cookie_val=f5_cspm.set_latency(f5_cspm.f5_p,res);window.document.cookie='f5avr1300495240aaaaaaaaaaaaaaaa_cspm_='+encodeURIComponent(cookie_val)+';path=/;'+'';}\nreturn;}}\ncatch(err){return;}\nsetTimeout(f5_cspm.wait_perf_data,100);return;},go:function(){var
+        chunk=window.document.cookie.split(/\\s*;\\s*/);for(var i=0;i<chunk.length;++i){var
+        pair=chunk[i].split(/\\s*=\\s*/);if(pair[0]=='f5_cspm'&&pair[1]=='1234')\n{var
+        d=new Date();d.setTime(d.getTime()-1000);window.document.cookie='f5_cspm=;expires='+d.toUTCString()+';path=/;'+';';setTimeout(f5_cspm.wait_perf_data,100);}}}}\nf5_cspm.go();}());</script>"
+    headers:
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Fri, 10 Oct 2025 11:34:24 GMT
+      ETag:
+      - W/"14e6a4953d8845365c0da051ca217040"
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx/1.22.1
+      Set-Cookie:
+      - _urs-gui_session=80b0d983431a3880d4f748f75f3447a4; path=/; expires=Sat, 11
+        Oct 2025 11:34:24 GMT; secure; HttpOnly
+      - f5_cspm=1234;;
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - 11acfdfd-0d4e-425f-822f-998ce7f82306
+      X-Runtime:
+      - '0.006468'
+      X-XSS-Protection:
+      - '0'
+      link:
+      - </assets/application-f6bf1b938c8159947246866978e15c467902bef70b069dabf6fee52c2d02f034.css>;
+        rel=preload; as=style; nopush,</assets/application-adccbf210b74fe4a7d457a0c2eb3fbd9f99407c4393065d95646d13d0451251f.js>;
+        rel=preload; as=script; nopush
     status:
       code: 200
       message: OK

--- a/tests/cassettes/test_utils/test_calculate_request_size.yaml
+++ b/tests/cassettes/test_utils/test_calculate_request_size.yaml
@@ -320,4 +320,144 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - earthaccess v0.11.0
+      authorization:
+      - DUMMY
+    method: GET
+    uri: https://cmr.earthdata.nasa.gov/search/collections.umm_json?has_granules=true&include_granule_counts=true&concept_id%5B%5D=C2036881735-POCLOUD&page_size=1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/+1a/27bSJJ+lQb/SmBREmlZsow77NISLXNWv46knJ0sBkGLbEtMSLaOP+RoAgP3
+        Gvd6+yRb1U1KlEU7ntlcNoNbIIDjZrO7uvqrr74q+ouyDrJUudIaSsb5J/hPv9tQgoxFMPi3L0rE
+        MqpcfVEStg3SgMdq4MOcTkPxWcgyBr/c0zBlDeWeJxHNlCuFbjZh4NEMJre2sd+MaUqbXpQ08yg6
+        +5jyWGkom4RvA58lYjVlPhuMZ4shjK9pqno8WgYx2y+cp+W8bbANaJwV8+SG6X4eTVPuBWLfFC3e
+        0iSgy5DhOZQ7Xet0z9sd7VxXD9sdRi9qR3t1o53aFTqd2tFu7ehl3ehFez/6S0OBQ28DTxrv6Je9
+        Tq+tX2pd9a8/v/8wt2d3OAcuLBQT3LGutS87Wv+yVz0IDOudC73d63YP1v3yCIufq2EQfxLvbrhP
+        qafyDXg+j/IwT1W4nYx5cLmtkTFxHOODfvkpUo3r2UQdd9TReHatbttaC++x5uV8Cdf/lTd/kVeY
+        buC6aKim+TJlWRbEq/1txvBky+S9j25tx3HPxmzLwrPOWWXps1HIlzQ8u+F57IurP3MYPXPy5J56
+        7Mxl0YYlNMsTdmbENNylQXq21ZrtM5hMYcuzN6Oho78tEJUlNE4RVrWgUn0IhSA8wdYXxeOxxzaZ
+        NLYOaY+NZyddvGZS7xWTOq/ZroLSFyZ1XzPp8hWTKpB+PMb0kzdqEf5YgfiT+bWAP7GjFv+PGAB4
+        25U7zJIc7vro3YHePu9eXmq9I2rYsyDgBxhK0dv6hdo+V/Weq2tX550rvdu8uGi/h6krAFMeMqCz
+        HCjrqgtnK1AGoORJPepLE7LdBpf3eBhCIMKGcDgF+BOxNwTojmm8yukK5zB4vaEYsReEIU12f2G7
+        B574IrRloMBTghEofi4c+IFxiD9EWCl4L5SkMmRIdggZeCKfY4xgyA725gyCrCRauJo7lqBTwBgI
+        LeSdIAvZPm7JuEOMPIXgCoG9iYxYMsnDLFAdFqc8ITirjE/yRpr9tkF8CLddg2itDvHZKmGMJCzl
+        YS4cAuYkjGY8gY0qy1+D4TQn/J5MID3xhId8tcOTsCRg6ZRGVcOQUEiHyA1Lyw5cQoBLSMElpMIl
+        e1thXRvSIDDJsMSD1lfbfVW7dNvtK/Gv2W4LPBQT5yEs9gqTG/BLuOR5ErPGwX2wzhz5NV2zRCTO
+        5tAwBjA6i4HQmQ3uyRNc/4syBoKXCFln2eaq1Xp4eGguedRc8W2T5i1artny1jTJ0tYyh9sFNKYt
+        uuHLXq+58e+VRwxCw/cD9AcNjSxLgmWeFTFcuJPRJATnZh8KzH9IM1jxQxZEiKEhS70k2GQSIWYx
+        l4zkXOLgXOLCXALUSwpibmJmpGEundq+VNs9VT8/cSrGgitjZWi4pmtNTEEDhWEh3ErFLBb79UaN
+        xbyKSXzTMmP/K1bpmtq+UHXtt1qFi31A02Jvd2LKUO5Exvvn+w07x0tbU7e6qgQ4Eb89t6hXhC1J
+        5eRYTi53+IZhUbHTcW1rOqqaOke+SOF8GbGGzxr7dFZp5XyGmFdHt2Cf2rkxNKN+PwCuI/WF+RlX
+        waAoBgZ8CzavWPHG7cy23s+mrjGGlW55EvzK44yGxeQhj2gQ49sjxkEOJzv8/4ADywagUpizAyMj
+        TBmG7ZqOZUxhlWv0FjC7DXwJXF0qhSlPsnX57LCEctUH8DSUd4DCuqfAJ+K5SeufF48dntevruLy
+        IvHZewI1Yv/0DF+e3MU84R8l4xP01RUZ7IBn/AT0fYgQVcc8bpDKrKHQSFfEZqsc0hFpN/WLkrxX
+        CWTWBnoRlFTgTeBHiFsePA63mEcFSN7xJPRJOZlICwlkfAwDMwyDTcoDv5w8coh44LAomNCPPDE+
+        Aw6vuue9S5BP6Jwhi3mEh+XJ7P4Gwg8wgReEkFau9P4lWNrT9fPuY+PYInrwmQRBDMHjHQblzf51
+        CFwRyzSIh24oP5+MLOIAC6Qh84II/DcUbklRkTzCpgX7FKiz2QaSHcCWFldxQNdjNROD72GVNMWU
+        MnCtOxOdAJDzaeLDMz/3sr26cLwAOIVVJALgGG5/xRHTigk73BJnYJnTAS7j8k3gwfhsYBpT1A0u
+        S6Lyd+Kak7lpG+7CNkVwSjEluEPDKDQN4izsG2NgvjRVfzL1ZraYAmdas+MNMJjdQjfJaJbW2xBb
+        IvciU8uha7YKYrzZcvilDAKuh5XBT6BKU3hH2IS3bKEG7KCrhzNLxAX+ULR286Ld7bWOyceAsAPE
+        ZLsi2aaQbX0eNHmywhUceJiVyuOFsghxHQO9PJVPR3QsXv0dnEyw7CnzGNmXPUJNyGLdZvcsQXxI
+        P5ZWzMRSIvsTK9qELCpBiYqlMKSiZo6F3dczRVXP7I0F/AKrMD+QrLK3IQWxJFUKmfIm6fX23oe3
+        3695vAKxFOBPscQtaC7QV2y1So/PupdrgAutrbb1kxx+KqiKG9y7iSxszBffUGcNgwSCeghJT4gs
+        sNOKZZej4B5gVUkGUGc/QK5QdYz28+vc+8QyIPTZEnkYHHcffEZz/6UFvnMOAt0HsACbpcbcAkG1
+        4QHm4X2Q0MRbQ5XflLs0QUdma4So7BmBA1vpuXdYRDlddMjBrBKQeCG/e3HbNIZCpymgwqlfV2SB
+        hAfc+IukKEkL+XBnme+IbY5B6g2JNb2Z2RPBYLXKhixSJrBZllBklAeQCAFseD44wgASD9hULF4B
+        rcSbky+zvbY0yMByJV2OFtbQHFtT05HLVDxReODjJjycHbYHvpNaSmizY1OLLEeEyTajPoixV5n3
+        dZ88OYBtDqy5eWLzKsjW+bLp8agwv4VXoibSFFJnsqTLQox8c2NH5hSy0ZgMZ4PFxJy65YyD2UXs
+        r9ZJmmYF+Z8YmfB8I0qK22C1JgcV8SxVVing+59JXIU8UBU+NSe7dd25Q1gR5PuqiSwT/lBA3ucP
+        ccipX3eOKusdHWRkugSBcooc1zZPcYON5ppQ3wZJltNQ9QXFgt5pHXoraau+2TNiGcIfifembG5P
+        eUaK5jUeYwL6orAzY5+z1jqLQjQ0+JWh6GvvNd/kGij+xGfX0jdFfQpVGXIWNjkgh6YEkpxZngTh
+        Ac/+ec/Vr1hxoDSili7Fk1ZhbfqnzX9+P79VjlSC+s5yFsbYel/Pte46j5Yx1CJ1LrsLUgBD8Gsl
+        bL7OmHNJQ1m5cPpiCoR3V0K2oitQbhyljAFkG9eUdeuhb3SJAlU/v7roX2ndZrfTea9Uzr6YD1/5
+        DrZslqg6UPsrUMH/ZtJ5I8n07V58PtMihLCWiq2BtwvFBvNl147A4iAGeUU8LqlQdhnJ1ox8rf1F
+        3lzzyVuSoyiHVTJRMAGvsGTDQ5k338yst2IbspIi9Gmt2STuGnb8mkSt6z1KtZzKmhNqldhPSQpu
+        h7IzY+IVvsRudiFK7xMekQ2FEmLLwMr7hIKuEJRXDkaBB7FO4X8J9QNsI2AWe4Akh2GeBlku2VKs
+        lK6huG0QKLPvMUmTZc53UhNHULHDSLEjOrI4nQtKF3JllMdFMkjLivnNyHXeNk9tztZwFWu0iH3e
+        YDsoxssDdsSGS3nVD1Dsk3TDGJwfQl68FZMuiVop8XM0RRjhU7jwpDJDr86IAXQZAZfA6h+F7DyY
+        X+KnSeCyGIKoqMSqLCgRdV8pduAwIH8BFBBX8iS4fEiTFcOZiADAU8w9ACliz+M8DIqiwA/k2ANN
+        Ihxj9/dgFFqA0RDAqUUXHiqxwlO4dJrjV02wfLkTdk9nhtGCMnlONL3ZI1CSpcXLlRNZsTwjuB3r
+        BbCoegONIwfAeUP6GU/DxbjNdjEPfXntToRAeaP1+523ZAJUtoZTaiXW0RteiM6QoYOBrvW7GlHh
+        R7+NTcsxl6h4rvQfmbORbcxvrQHQ60jyaUm5QGjGWJBKKYxfQWfYG4V6u4vUpF0c6u2X6AzegVpM
+        7+OnFL1fqdEbJ18YCpEnjTiqr8tvGmOoAcux30p/YstDi6XaW5TNkQ//hZnH/bloPA4YElPRkeDF
+        F2fDHtxad6aNcyzsSV4v3JktCqOKvVPDMVo/zcetQokfGT5fAzKw0zbzGI05JN7Nekf2+R7QaHj4
+        lZQYstQh0pAG+Qnbpwnf5CF6jYzpkifY+No1CG6I306wu+VlJ/XlcYFzqjX2pz1SGreziUnmxuhU
+        jtUlUvkJrrBAXM4T14miQ25DimnoNzG1cA1U9hsCGf/Ts2cpRicMyu44SKMjwJqRVAZlT1ma+eca
+        awUWXucXueE/6Rj0TcUVc3s2MB3nFDjGoiW/6VXw8syHpOrXo+9x76c9EHmwQwuv+pFyKMhdJf9B
+        3jH2KdzhQedgTvEd/nBnwKYO5kkRDCqoCcD/YeKxd64Xs5+xDh6sKaogSG+QLbyjj1azZBlkc3jC
+        /RPxOBWd4pBsxGN0KKifDbCEl9D77O//87+gBgLs6gNrb0syKRQPLouvhjRm1e9Far/fF9xVKtsg
+        Ft/Rjr5d3IxnxtFXHSsGZo+pbNjDhiemOnuzCLYrsOfuw2EpJhyRZY8MEllGUEaRZsz/zpEYXjK0
+        bFPXGQp3ZcWALtGDOWXjoW3duNZ0RMr7qID15NkLd+U80Gz9LvCz9b/g/H8JwkKv1btARqxbKa/I
+        7JDmiVPKxqcYdXJAmTqdz4/9IobJtFTNc5C7iSoOgWJlDuvHYAooxB8L3lpb+0Ogu99rat8E23eW
+        ZT+BNJSVARQLqlVWAFZEVyxR7b3kB7UBSPiBwH7e7rS/B9hHAyiP32lPhJmsXcAX8YodrTMJUqFc
+        tDRT38GayY8G9vYfA+yXTa3/TdAOZbGtH9+e4W+pqBkn+9rW8aj49EYqiNd/ILRrnYvvgvaJ6c7m
+        qnHsr4Mmk5q+0hrZLwQ6yPjRoK41z/8YUO99G6Tf3dq2ev4M1qEQ3Z2UkQe0i/d+FLTrnfZ3QTv2
+        QlS9feyxn8RXAKFeKvAuelIq0X40lOt/DEL/Vsr83+rlt/P59e/i8+sfDen/5vP/P3xeado6G+YF
+        98XXAWz6PPlu6sd13/zyKKp8KW1ttaZ22cQ/tCscsJhMVOxaVhu0YsZjQym6kkbsv/AnLTdByIqJ
+        R0/+Vvl4GLNsMLxRcVs5Vhx0KjwGo4b8c05cS35C1Jr6yWjliyK4BUefNev/dvNHbPL9A31QZrh4
+        NQAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out,
+        CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+      CMR-Hits:
+      - '1'
+      CMR-Request-Id:
+      - e11c14d7-2f2e-4ec4-a71d-c63bba1caf3c
+      CMR-Search-After:
+      - '[0.0,400.0,"GAMSSA_28km-ABOM-L4-GLOB-v01","1.0",2036881735,14]'
+      CMR-Took:
+      - '197'
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-MD5:
+      - 82d4da7b87f95d3a0ea5c008fabb15b1
+      Content-SHA1:
+      - 785ae85da16f69d0b17913a93f1795c182458aae
+      Content-Type:
+      - application/vnd.nasa.cmr.umm_results+json;version=1.18.4; charset=utf-8
+      Date:
+      - Fri, 10 Oct 2025 11:34:31 GMT
+      Server:
+      - ServerTokens ProductOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 cc40ca81f7668e11b3a0c1d942a641e4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - G_pXzJxULFaPT0PaxbDXltW0HEZeoUbQ6P6bCfhC9LE8cclaflIJyw==
+      X-Amz-Cf-Pop:
+      - MSP50-P2
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - G_pXzJxULFaPT0PaxbDXltW0HEZeoUbQ6P6bCfhC9LE8cclaflIJyw==
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/cassettes/test_utils/test_calculate_request_size_no_resolution.yaml
+++ b/tests/cassettes/test_utils/test_calculate_request_size_no_resolution.yaml
@@ -180,4 +180,186 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - earthaccess v0.11.0
+      authorization:
+      - DUMMY
+    method: GET
+    uri: https://cmr.earthdata.nasa.gov/search/collections.umm_json?has_granules=true&include_granule_counts=true&concept_id%5B%5D=C2723754864-GES_DISC&page_size=1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/9Vc63bbyJF+lT7cP1KWgEjqau/x2cAkLNEjXkJScibjiQ8ENEnEIMCgAcmyj98p
+        z7BPtl9VN0CAomR5Mt5kfWxTBPpS16+qq7v1pbEMM9V42W42siT5iB/ODpuNMJMrPPzlS2MlM6/x
+        8ksjlbehCpPYCoPGyw5aBzKSmcSXuRcp2WzMk3TlZY2XDW+9jkLfy9D44DYO7NhTnu2vUjtfrf7z
+        byqJG83GOk1uw0CmPFrj3J1+6PWnXbxYesryk9VNGMty5FwVDf0okfhi2ukZQWaW5mjmKZX4Ic+r
+        iOJbLw29m0gSH43rw/bxyclxu3N8aFWmKx8fHu983D7d+fiovfNxZ/fYx2e7x35kyhe7CWztpuQR
+        djq7W1fG/rXZgChvQ18LaNo5PXxx0jrtnNQmmh4enh2/aJ2enFYk8etX9D20ojD+yH3V4cuDg4VU
+        Qah8y89XeZQrCyoO6L9M+jCTg/Px4MPlIX8c9gfu5Lz3xm6dHhAZpEu1huK8yFL5jZJZFsaLQq0x
+        XtxKYyiV3h9ap8YOstSLFRmDKk2mYgtWAAsOowcm8aXhJ7Ev15keeqeBfG0+1qpqL4+3qprP462q
+        1vR4q86z6Kra2hN0PY/6F8+SROtZPD5Pqp1njVWlq27GW112GvWDgXfa+FcycrKuis1og6z17XZO
+        O4enx0dnJ0dVtynRMvAyAFmj0+ocW60X1mFr1j562eq8PO7Y7U7rL2i6gPXmkQTq5THgs91qtQ+N
+        XcvVOkl3OkVBQ3a/puH9JIrgZpgQ3DWAs2TsPS/zLr14kXsLauPGiyhUS8zoxH4YRV56/5O8v0vS
+        gH3YyVaJWi9lKptinEo/XIcZ+09TXNwHaRIli3ty1m45Vdc00HLvptLLkhQTXeTz+cpDv3P7rd0U
+        rv3GFtMs8T/KtCl69swWr5PoNozp1VtbDGX0kb689fyPCA5i5lGAcINQj+bEQSrvxdS7zfyljD8m
+        eEmcgUYlY03BG/g+mvbCBUiKxNQPJcQjqBlaj2IAlZxIleSpL0kylwAuLZRllq0VwIuQy16oua+j
+        1SK5PYDmvI1cD7agx15mq4iEPc5vSKySaD1PgsBLA+F6abYsyFBMh/DiQPRjHbIwnpgaoxVdcCFT
+        sQfrEWQ9+yB5FmaR1HgneE7xJozBWU0x4vJQtEXg3YuWjU+5SKUUn6pfrhkiMVMo1dBbyS0ExbsJ
+        grinZK+00kOrdWq1O7NW6yX/tVstttJrmZI9oxGPafqNI8/nUTFbfCOjrCkGPfbJqcZz91Mmyaq/
+        oAmbuXk+keuK/siPnMnMnfadIQa/SNLwc4J3kWndS1ZeGPMoMkFCkt7Tz90EtguxZHJ6r+ArW6O8
+        hj/h9WICBcILCtB/J1VWvNqM0Hhptc9azcYwgeZ2vX6Bl663uyv3nCb57p7Wixaw5OvXquuM0wQK
+        UorsuzvrX7ukJlBJ1oN3Qe5nZSgzZlTxVbCOkRcJiaHhguULMe323WGXhpkl69CncWeD0XR84U74
+        oWQHGU/cbn/cnzmz/mjIOPi7DATrMBh5KW9l1N5uIJzB6Go4+z+ccOLM3B863XR02e+JJ5t1qNlw
+        9O6H0nHZ/9PVcwiZOP0h++XMxBTtmNqaJnAPhoBZuDJe8louwjiGJRePMUb7xYszq9XG3y10gHlj
+        ZNgt4EyhD89KHtqnCHlIKNkb9Tkk0Uej3bKPWyenBKkHBooOes7PB0AWNJ0u4YO70cqN4fq/HzYC
+        cyvj7wsvEwUINwyw62XMRM4RF+MixXDg6TrSJfGiKX5GkPvJFpe2uFB5U0wR7ZI0SdQypCBIuP9n
+        W5x7SX3MEnJbRzuFugkCdcZclYUmhMzTZCUmcoUUO0KElLGSiDErRLb0XlyRJjC7cNIsnIdIhiOE
+        2jzljwxQ8lF0oyQP8D+SZWph4pLG0iJsYH7EaAdLOlsMsN4DZxEZWBLlrKGjQ2ILU1JLLB2PgKPH
+        Hbb5jZg2CYGgjGBiC6QEThDphEBUMgK0OM8pMRCVzADCHVOTOx7kZ8iZ5e7yMGVmQYLGYK9t8S6J
+        5vPHpH36DWnPllLMJoOBGORRFloKHaMIy+Et+3JgcvcqVC/Fn3JPhdZ5lNx4UdP0+ll6oKir17GB
+        RapJUrFTkcgAYHcwYYmEwYukvSV6Tr5WLHm7KvizvfZ+RfSHZ9bxcV3sb5N7X7K0SeiQ4J9DqcWE
+        YUnCXpzchd7HRyTVbn9DUj95ERQC0iPKX157ZH3dwWgyvngmC+1O1XaOj5B4HJ+QPW2jRbt9enzw
+        9mJg9SyiqoPcufG1xuskD6D0JrSvObyCYfjLWFKN4TFLOP4Gf10v8vNIKyuZi/M0DAKwWNci53bI
+        6kQGu9FGIJB0Q+d5OkdyZPywH1vTMMsBA/lCitENLVlM8lyRFUGoTXPRYB1OGCFapBG2mZVsO/1I
+        A56nSb7mb2qZrKtSxUKjcyZGfpbcQC2EL7DKhAaS97BJR1WE3jlsW52jU44MsGPY+b1xgb/rb5qY
+        UAE1U6zCA0BqCKxZ6xxF4IUKVyHWEiJLmOpaPyl0zi0ol4Zzb9D24gIKCilJ59Hxl1q/bzCUv28I
+        aZyjGMfzuayAJwEmryqgkD2wvilCJukGvUVO5niHFYNYhoslPaExUs+/F8yOClMZaGOh7mBhQf8j
+        KqLFXkesILKl2hc+TPwGZCZAK5qeLLg/HXHUNlE91BWU7mV/4MxGl6Pznw8G7swdTfTPlcAOMfcw
+        r5/1QpWl4U1OLFRWBWT1E4ReTolzZd2BbqvDZRisrwJEbMC4csZ9Nw7WSUiZ9WYJAxnbpghjS1qB
+        8JNyPaMO/c0QO4bsJRBxkZFfTS5/69AT1+kNOKE9fJ0DmjOs4EY3fwPTsOF5+IlC+z9fNUKi4PiU
+        b3ThQ1mK5UHGFZ6eVH4ars2qYpjEknIKLFdId1dppCN4vVWPbdqpmNhupBZ7bJ77OvBu8o+9R3KM
+        /a0EAzLZkmviExDIdCPchD43kl0zcB1AICRAzphu0uROyQfr0XW80ON3ydfjbKYrA9ehIo/8XGoV
+        +KbfnLszMXEvkSn3xHV/euVc9v+yWRjUJaRFbfwsA9JncBVe6Yg1oEQLhBHQ5E/iTt4oRE37Ic+/
+        baVdkt1zZo6YgvZLZ9jrD8/F2Dl3d3G+WW0RAd/kSdyGnriYzcbTByQv1qv2oxqivo+aKZwgv8kq
+        hM8mrltXAT3eRX4VIZ7PAH0ZjeWw54wJpJEbcbr2Hfwka4ll6PoxlnxNpCq0suFvNHZ5WsOQYeNq
+        6kJbk+t+1xUAmd/GKQWk89TpTXW4nbLPwLl6030Cc+Qx4DulULCigFEIIFsiszI7DQhUZRGNQV8h
+        I8EPOosTRQkRQSJNjFB18JXZQxt+2iCSQD2w4RAYX5PW+YTZ0cY8uXYnmp3fWXCPmcjsYuL2etPv
+        5CxbAuXBHBIpL0oWB94CKLfwHjgt24lu89BMzNQ/wkyulGTu3CJCwVK81F9SbjIPoXPSeyoxChao
+        WiCwiFLnK0rd15F543NZTj0UkeIxd4ZBfvPff3/1cJtiw/82cb8XGsw0+lqMvmy6nk8bJ0KXP0Ut
+        EAhnCGkMjfFza05W987D5NbDwl/7FaG4dcOJfZYkkXYoL4oQgCi/ShVJln3osxQLkx8zb+GGAITW
+        RJNwFyJbzzOx9G7JC9E3SO7iKPFIM/fccYdFGoq2YsZ/UGtTE3u1qRBUHKw/unaGw/5zAt5z4iZJ
+        vE4ZKTJPwZG9XqsHzlKkU0qXOD5ct04/OLPXvQ9zyiHsdTCvketcno8m/dnFAL6JzNGd9bvOpXjt
+        TPtwlVH3auAOZ2KPBqhgxHXffVey1B++GU0GjzJUWQLtNiCdy8wklk1oF4laPvhALd/HfDlqbdBH
+        RDHulxwX3Pw4fs2qBz4QyE+/T4LGA1+3Tj78qf+v4q3r3UoPyEaLI82n5HofuT5cM9EVDnjo78wx
+        DYtRLV/P/69iXy9BSgv+7QkdpHGgB7Px5AE79MoauD/UQM1OixhiSaR2cbKhPDVbXIroNv4XrmS6
+        sG5bp1aqB7JiM9CGjf5gPJrMHADMcATc+VH80IKJIvAa2BEjXVNcFeP0bYVcIVcCYZmWcTuYRCDq
+        8NedcJPR1wPnNVsvNf9QjvkwAXGGowGg353+QDbH2jnEBSWZVGx5UnEbQsaT0Vu3OxMXI5jvMxc2
+        v+r9UKprmcVtfTNvV4XLDAT7Nfskz+5zNe5xH8zq3NDCm3aqGu9jsz8oWqdFMcfP0xREi1vzxlRy
+        irTLFqMogBWY1wrZQRSJOBFREi/w/AbZ+S0W5rSNwWaDrEHiqYyRya/RSVKycXMvNjPb7+P38cxk
+        7guu1mxVcV24E6d/XqTBkZS1x462b4CS856hM3XKIpepRVHKstAFPmVqe/VKVFoUcz0uOQlyxygv
+        yoctu/0//yALT+/BSjS3EDuJS7PPQoW6li1EnytY5CKFwP5GdR6myHrr/Nkpioz1EsUArp2nknye
+        iw77YhUqxbv3ORcgeXEOZrtJuqk/JqBlU+D2tN6U2Yek/MycxNpiNKmUL/XS34t1xhfzQ1DnU1UG
+        45bV03IaZQjyAqR1PmWWnBv8PZeK2GcdmJobl/BIS1rslqL6uKgcL1NE8x3Gpc+E1oQpF88Up5pC
+        QYxATgwAswL88ZZYqbwqF5iZ7GZOvJqTSLoyaHbLtnSpqWRLNtkwBLcigd3US5WmKKoJL0qZG/qZ
+        uTD2U8k5tvoIFyiFsGR9UE1pkhcc3XrpPQlP1ylDCDOMibY1eJCcjMMK4T40V3WeWMpAvcS7dRhY
+        ZfuaJPewMEGqjrma4shaFqXQ/SZUt5IHMRIIi/bT6p0uqSzGfdr1Tgz0icowGzQHB5JEp16O6TKa
+        7nZoH1tcai37QgDvliHkpcVA655bqb2VrAoLIS7R0gRFRbdZsWJZbqtABnW79WD68tOaK4skLEYU
+        qI9iEYlemxAM+jODDJuJapITYFX4CcaQUp1R8+YnnqKzJp+TmA3X0YbY1NC3hBK4Sg+P25C25RQ0
+        GQtmBbHCfRhuoBXarwOsKrPcms8pkqgsD0IWg6/9ByPwgtW6h1D1jCBEIyAVuE2ZzoAxEcLbsuLQ
+        yFX8gbXwB6Grn6LdEp/ov4+r7W3RovRfFvlK+EK/TVMq6bMXFe2hbxCID3PUQ1Oidb9d39fbCisJ
+        x38IqmTkqxUSs3tbT7DhTWO0DgTzMFUZayvPCsh7YsQ9DElM7NMXjcu0hMXCn9Ro9gXioipwX4xo
+        uMJ8nSNmGFSswjhchZ+l5hBmr0JCmgBD3oQeO2kZ5m7knCD4faN1+r7RpFeMEOFKVx5IDFmSUXzS
+        Jg9qFO1joE+kazng6OispoQaIJOVI76FQXVrRAsOlkdbdXlMJ2/h1vBkcAUGmPuUehp6DPAHYM1P
+        kzuPDmDGc2phqihwBLHgzaxCHU1RnJQDczWRE5/aX9drGCvLgzdlUqIohGWTC82WuWJ5rBJSI4Ys
+        igywERN4HwysQdikDhn9C8mFqJoQzs2mva2V5CdpqtOmpljC6W9p0xjPdR+m2zBPtFnFRlYpgKJy
+        RLu8FU4H7x7wqrVFIyW+zoJ8NvSa/rSKqlpkhYBpJDd8cqHQC3QBhNQa5EOCqvCab4/BEOdFd969
+        0rmTKYcGFDEpD0OIJH8oGNKGX4pd26OWMfGEoB3qahBSFFAWJRRGsmJpyeEOmFWKxwxG+3KUTZgN
+        VWlMjPWx5Z16Rk6laG+fwBAmqoOfSfQK1yl2DgNAMKnO5GuGkMInN+6IjIiTFExoDi5Wc9KafMkT
+        gFCwqlJexjb0TuZNntG3e26YxKB4AcjjebVTaJ9exHyuwqh/g3PMXtOUIzkqpJRoVoDAQEA45zp1
+        wsUztZRKF83w0BZFslvsWRYzGPStw3uRywaSyvuKooduHIVsY6azDg1F1wsyrAttWMUAhPcl3Bc7
+        uCWykDjMmFpknrjxMn/ZFHRela1SB/sCmshw0IcfNrWa8zUxeWQ2YAv2EOIT7ec35YzMdjGSjivM
+        bVOsI6wmvRsqNnaOBPlGCTDSXtjcgZqGJrF468U5UitRZJ7VLEGDFqWQ+ECPVLuws07DSHS0Hgpd
+        VMIYu9WeDlv7orKD/p2RqhamvE2IqqA7vJN3v58fs0gQ1H8r7MHJNWJs/SH2xszbByaT/rwS06vB
+        l3Eo/iDav+CDsejXr+JAmJY+liJ42TkCyr76pd0czn+lcd4ROL4sx6NWeqjqKDxhWCfCqgFdGEN2
+        zTKOp/vv4+F8u8MwX9EZCBh3tes8rCBkUwznr47O3sftX+xf6737cUCJLsQ0z2PGlf8SbX2kALQR
+        OhOxTdESvP0EB5U1th4QoeE63axAtzRqSOIk7rx4qg30bhkicd4M/qrV1CAlM727ge4YMi9jmHZ7
+        ZhXjUfFIQ/M4fNXSa1xNDXeyKwomymnkXcBnROepEuHVdkim/gjLZIoPYqN+1zSpfKrXIbSJTDkP
+        uUCZa/QnlsZRGmfzmJF2Iz+G7H8HDKbImOogSmUsjrabmbBsYIbzKGBsMalvJaE2p2SqRoplXIC3
+        uu9eJd/QL1x6/r6xXyTEm3me0BslQUUINug899SSoGbrFM+T6bgNrAV+NTewVRz2Qc5EuF/lY4tg
+        UU1KmSAGwepJHA1WBF3w7L92yLd1wxhgZTBZvyFktTXwE+jr6UWaJHrZ43001iCzKgoayKDOL9nu
+        IbcPmuFX4gtDkdjjh+H+Xzsa3vibASexLwjlhjDmD3iuMe7rX1v2cRXoNq81vO09HIYmvyvQkF+9
+        z95nO2FuS4rNDehtqKeuAw/mTvl03dbZMpol2xvq9ITbCLUpT2mTKpfURLGz4DUw6zvn7fZC7duq
+        NrG04l2FmvV2/WalbloWEXJTsdpUAE1ithPd+IBfijyvOL/5oP43LdfgT9T/vIjOcmXLVXFAbBFr
+        a4soTHoGUb5R56q5C9fcbz0gaqX8RYkw3ZUBd1zrZAGlAXXOgVVJuiI4DFfyQK2pTlXsq9YdcSO8
+        wqFoiSQ1HtQ44YoB+qMTz1vIlk/JletwhAbp0VY5FSTA0rrJrq0b46U+WUdrLE90I92HD2NMmHro
+        NaLN3cVSCymQEE7IoWKZrJKFjAkYvYJXPC7SctrxvUx0QemxOw7n7uh84owv+l0xcc9r+0bnl6PX
+        zuX2GftvduDTQ9/fa9R1HX2OfoA1RPBI2b1jtY6szvF3lt3bnV33bmbFThPtUewq1T/ep1Kq37q9
+        Y7YnNN1b5+1ZHfGiePCNYjOPfqXkk6fwZsWZDFN4JqPSx8wfuRql3+25o2mvP93XIYyWkVx4K6hY
+        5GHAYZ0cgAv2+tyGxhKPT77QOjcTxZ7LjiMbMl7AsfnQE13V86ziIJClknl2B1yz1kkUUqmVNwYt
+        kGEVMyP2cP12Qzn+LpM7Xh6nGJMQ3OfSOhcrP8bJXSSDRRGUi/DPxBcn55rwkbnkSPyNI3NMh6ST
+        Fcpu8PWiOPP8DBFBFZfyJom5/txH8ISrL/iKHlTGEbzQsTua8E7TpVc+u7h682bA16jMqFuHVJ0g
+        oPtLxvSnWSplVn3W0DyZ+3BTBrI3UbhYZua+G0Ye0K3cLFmLk3aHbxbq08flXTJ9JyqTY8poYr5n
+        NuiR9SZUee0mgXaD09M2k5nHfC+scTV12CoN4QNJtdFQmevsxjdmAOb1kk6H0mUZpMB0hL7Vtk7a
+        R9bJYeuMPc20feN92tHq+OhFp9rKXYGdSrtzmaQLab+1ze2HP5a7fXQbrFnRTQElwpxm31IPgGri
+        /lxXz9S5nnUv3OFPo9+uofJIEZzE0UeFnNRf0qe5kjiTlKOjERDgoX8qcYkVdsq7SEwFso6Tdsum
+        48rf1P6/kbqPT1vHTylSX0C1NxdQ65o026+ary2vcybdi/61OyF2qzBL4jk4n77pHkzd3oE77R3M
+        +tPLA0CAuXtUReB/5k4pvWIUKkbpOU53v/kdmm0+mDjUN5ub5TVbosL9tI6oB1+J4BPu9E02nzKC
+        JgPfowa8fWb74Zm4Uuy1c81be+dPHz2myyb1E+NVLBbv9ClmfRnckMk3L7YUzdowQjfNSOfctERZ
+        M+aFezkWPXf6E5YFYzp4Ic4no6vxb3fkf8JC/l/7badz9AyY7pycPeXdZA5WEFlLGa0tMpA/UgO7
+        7uJ8vRHWaH7HxIY+c7pAX+8qroQ16s7Oq4u6T3/X+QS6b8Lrp1V5YbOGJaOZcMbjy37XeX3psohX
+        tBQKRvMHbXeSK/j+ZjWnna6R7RUXAskE627kB/Gu0685VpeVU/y3bbt9Zh+RUenJrwYDi38ZSZmL
+        mhZ0lUMHHkDtExdj3mC5ZxrW3tCNTL1AoxbT8DNdye40tx9eYWVMMngNGt4Uv6smllmXD47qJ0at
+        Q/6VI6x7/Ptf9FEdWyJHAAA=
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out,
+        CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+      CMR-Hits:
+      - '1'
+      CMR-Request-Id:
+      - daca3c8e-3c8a-4c8b-85a8-af9b5d61c763
+      CMR-Search-After:
+      - '[0.0,6400.0,"GPM_3IMERGDF","7",2723754864,21]'
+      CMR-Took:
+      - '184'
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-MD5:
+      - 498390bb2aa8596180653158a84975b5
+      Content-SHA1:
+      - 62554c0aba47fc01c4d3326cae00190245c4121a
+      Content-Type:
+      - application/vnd.nasa.cmr.umm_results+json;version=1.18.4; charset=utf-8
+      Date:
+      - Fri, 10 Oct 2025 11:34:30 GMT
+      Server:
+      - ServerTokens ProductOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 735ddcca68d7fc25d4f56c0eafd34e64.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - PpNHFf6T5-UMMNYuXM9I-cABpOYvciVcx_44xYqRWLN5j3u97aZURw==
+      X-Amz-Cf-Pop:
+      - MSP50-P2
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - PpNHFf6T5-UMMNYuXM9I-cABpOYvciVcx_44xYqRWLN5j3u97aZURw==
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/cassettes/test_xarray_backend/test_timeseries_statistics.yaml
+++ b/tests/cassettes/test_xarray_backend/test_timeseries_statistics.yaml
@@ -139,4 +139,144 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - earthaccess v0.11.0
+      authorization:
+      - DUMMY
+    method: GET
+    uri: https://cmr.earthdata.nasa.gov/search/collections.umm_json?has_granules=true&include_granule_counts=true&concept_id%5B%5D=C2036881735-POCLOUD&page_size=1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/+1a/27bSJJ+lQb/SmBREmlZsow77NISLXNWv46knJ0sBkGLbEtMSLaOP+RoAgP3
+        Gvd6+yRb1U1KlEU7ntlcNoNbIIDjZrO7uvqrr74q+ouyDrJUudIaSsb5J/hPv91QgoxFMPi3L0rE
+        MqpcfVEStg3SgMdq4MOcTkPxWcgyBr/c0zBlDeWeJxHNlCuFbjZh4NEMJre2sd+MaUqbXpQ08yg6
+        +5jyWGkom4RvA58lYjVlPhuMZ4shjK9pqno8WgYx2y+cp+W8bbANaJwV8+SG6X4eTVPuBWLfFC3e
+        0iSgy5DhOZQ7Xet0z9sd7VxXD9sdRi9qR3t1o53aFTqd2tFu7ehl3ehFez/6S0OBQ28DTxrv6Je9
+        Tq+tX2pd9a8/v/8wt2d3OAcuLBQT3LGutS87Wv+yVz0IDOudC73d63YP1v3yCIufq2EQfxLvbrhP
+        qafyDXg+j/IwT1W4nYx5cLmtkTFxHOODfvkpUo3r2UQdd9TReHatbttaC++x5uV8Cdf/lTd/kVeY
+        buC6aKim+TJlWRbEq/1txvBky+S9j25tx3HPxmzLwrPOWWXps1HIlzQ8u+F57IurP3MYPXPy5J56
+        7Mxl0YYlNMsTdmbENNylQXq21ZrtM5hMYcuzN6Oho78tEJUlNE4RVrWgUn0IhSA8wdYXxeOxxzaZ
+        NLYOaY+NZyddvGZS7xWTOq/ZroLSFyZ1XzPp8hWTKpB+PMb0kzdqEf5YgfiT+bWAP7GjFv+PGAB4
+        25U7zJIc7vro3YHePu9eXmq9I2rYsyDgBxhK0dv6hdo+V/Weq2tX550rvdu8uGi/h6krAFMeMqCz
+        HCjrqgtnK1AGoORJPepLE7LdBpf3eBhCIMKGcDgF+BOxNwTojmm8yukK5zB4vaEYsReEIU12f2G7
+        B574IrRloMBTghEofi4c+IFxiD9EWCl4L5SkMmRIdggZeCKfY4xgyA725gyCrCRauJo7lqBTwBgI
+        LeSdIAvZPm7JuEOMPIXgCoG9iYxYMsnDLFAdFqc8ITirjE/yRpr9tkF8CLddg2itDvHZKmGMJCzl
+        YS4cAuYkjGY8gY0qy1+D4TQn/J5MID3xhId8tcOTsCRg6ZRGVcOQUEiHyA1Lyw5cQoBLSMElpMIl
+        e1thXRvSIDDJsMSD1lfbfVW7dNvtK/Gv2W4LPBQT5yEs9gqTG/BLuOR5ErPGwX2wzhz5NV2zRCTO
+        5tAwBjA6i4HQmQ3uyRNc/4syBoKXCFln2eaq1Xp4eGguedRc8W2T5i1artny1jTJ0tYyh9sFNKYt
+        uuHLXq+58e+VRwxCw/cD9AcNjSxLgmWeFTFcuJPRJATnZh8KzH9IM1jxQxZEiKEhS70k2GQSIWYx
+        l4zkXOLgXOLCXALUSwpibmJmpGEundq+VNs9VT8/cSrGgitjZWi4pmtNTEEDhWEh3ErFLBb79UaN
+        xbyKSXzTMmP/K1bpmtq+UHXtt1qFi31A02Jvd2LKUO5Exvvn+w07x0tbU7e6qgQ4Eb89t6hXhC1J
+        5eRYTi53+IZhUbHTcW1rOqqaOke+SOF8GbGGzxr7dFZp5XyGmFdHt2Cf2rkxNKN+PwCuI/WF+RlX
+        waAoBgZ8CzavWPHG7cy23s+mrjGGlW55EvzK44yGxeQhj2gQ49sjxkEOJzv8/4ADywagUpizAyMj
+        TBmG7ZqOZUxhlWv0FjC7DXwJXF0qhSlPsnX57LCEctUH8DSUd4DCuqfAJ+K5SeufF48dntevruLy
+        IvHZewI1Yv/0DF+e3MU84R8l4xP01RUZ7IBn/AT0fYgQVcc8bpDKrKHQSFfEZqsc0hFpN/WLkrxX
+        CWTWBnoRlFTgTeBHiFsePA63mEcFSN7xJPRJOZlICwlkfAwDMwyDTcoDv5w8coh44LAomNCPPDE+
+        Aw6vuue9S5BP6Jwhi3mEh+XJ7P4Gwg8wgReEkFau9P4lWNrT9fPuY+PYInrwmQRBDMHjHQblzf51
+        CFwRyzSIh24oP5+MLOIAC6Qh84II/DcUbklRkTzCpgX7FKiz2QaSHcCWFldxQNdjNROD72GVNMWU
+        MnCtOxOdAJDzaeLDMz/3sr26cLwAOIVVJALgGG5/xRHTigk73BJnYJnTAS7j8k3gwfhsYBpT1A0u
+        S6Lyd+Kak7lpG+7CNkVwSjEluEPDKDQN4izsG2NgvjRVfzL1ZraYAmdas+MNMJjdQjfJaJbW2xBb
+        IvciU8uha7YKYrzZcvilDAKuh5XBT6BKU3hH2IS3bKEG7KCrhzNLxAX+ULR286Ld7bWOyceAsAPE
+        ZLsi2aaQbX0eNHmywhUceJiVyuOFsghxHQO9PJVPR3QsXv0dnEyw7CnzGNmXPUJNyGLdZvcsQXxI
+        P5ZWzMRSIvsTK9qELCpBiYqlMKSiZo6F3dczRVXP7I0F/AKrMD+QrLK3IQWxJFUKmfIm6fX23oe3
+        3695vAKxFOBPscQtaC7QV2y1So/PupdrgAutrbb1kxx+KqiKG9y7iSxszBffUGcNgwSCeghJT4gs
+        sNOKZZej4B5gVUkGUGc/QK5QdYz28+vc+8QyIPTZEnkYHHcffEZz/6UFvnMOAt0HsACbpcbcAkG1
+        4QHm4X2Q0MRbQ5XflLs0QUdma4So7BmBA1vpuXdYRDlddMjBrBKQeCG/e3HbNIZCpymgwqlfV2SB
+        hAfc+IukKEkL+XBnme+IbY5B6g2JNb2Z2RPBYLXKhixSJrBZllBklAeQCAFseD44wgASD9hULF4B
+        rcSbky+zvbY0yMByJV2OFtbQHFtT05HLVDxReODjJjycHbYHvpNaSmizY1OLLEeEyTajPoixV5n3
+        dZ88OYBtDqy5eWLzKsjW+bLp8agwv4VXoibSFFJnsqTLQox8c2NH5hSy0ZgMZ4PFxJy65YyD2UXs
+        r9ZJmmYF+Z8YmfB8I0qK22C1JgcV8SxVVing+59JXIU8UBU+NSe7dd25Q1gR5PuqiSwT/lBA3ucP
+        ccipX3eOKusdHWRkugSBcooc1zZPcYON5ppQ3wZJltNQ9QXFgt5pHXoraau+2TNiGcIfifembG5P
+        eUaK5jUeYwL6orAzY5+z1jqLQjQ0+JWh6GvvNd/kGij+xGfX0jdFfQpVGXIWNjkgh6YEkpxZngTh
+        Ac/+ec/Vr1hxoDSili7Fk1ZhbfqnzX9+P79VjlSC+s5yFsbYel/Pte46j5Yx1CJ1LrsLUgBD8Gsl
+        bL7OmHNJQ1m5cPpiCoR3V0K2oitQbhyljAFkG9eUdeuhb3SJAlU/v7roX2ndZrfTea9Uzr6YD1/5
+        DrZslqg6UPsrUMH/ZtJ5I8n07V58PtMihLCWiq2BtwvFBvNl147A4iAGeUU8LqlQdhnJ1ox8rf1F
+        3lzzyVuSoyiHVTJRMAGvsGTDQ5k338yst2IbspIi9Gmt2STuGnb8mkSt6z1KtZzKmhNqldhPSQpu
+        h7IzY+IVvsRudiFK7xMekQ2FEmLLwMr7hIKuEJRXDkaBB7FO4X8J9QNsI2AWe4Akh2GeBlku2VKs
+        lK6huG0QKLPvMUmTZc53UhNHULHDSLEjOrI4nQtKF3JllMdFMkjLivnNyHXeNk9tztZwFWu0iH3e
+        YDsoxssDdsSGS3nVD1Dsk3TDGJwfQl68FZMuiVop8XM0RRjhU7jwpDJDr86IAXQZAZfA6h+F7DyY
+        X+KnSeCyGIKoqMSqLCgRdV8pduAwIH8BFBBX8iS4fEiTFcOZiADAU8w9ACliz+M8DIqiwA/k2ANN
+        Ihxj9/dgFFqA0RDAqUUXHiqxwlO4dJrjV02wfLkTdk9nhtGCMnlONL3ZI1CSpcXLlRNZsTwjuB3r
+        BbCoegONIwfAeUP6GU/DxbjNdjEPfXntToRAeaP1+523ZAJUtoZTaiXW0RteiM6QoYOBrvW7GlHh
+        R7+NTcsxl6h4rvQfmbORbcxvrQHQ60jyaUm5QGjGWJBKKYxfQWfYG4V6u4vUpF0c6u2X6AzegVpM
+        7+OnFL1fqdEbJ18YCpEnjTiqr8tvGmOoAcux30p/YstDi6XaW5TNkQ//hZnH/bloPA4YElPRkeDF
+        F2fDHtxad6aNcyzsSV4v3JktCqOKvVPDMVo/zcetQokfGT5fAzKw0zbzGI05JN7Nekf2+R7QaHj4
+        lZQYstQh0pAG+Qnbpwnf5CF6jYzpkifY+No1CG6I306wu+VlJ/XlcYFzqjX2pz1SGreziUnmxuhU
+        jtUlUvkJrrBAXM4T14miQ25DimnoNzG1cA1U9hsCGf/Ts2cpRicMyu44SKMjwJqRVAZlT1ma+eca
+        awUWXucXueE/6Rj0TcUVc3s2MB3nFDjGoiW/6VXw8syHpOrXo+9x76c9EHmwQwuv+pFyKMhdJf9B
+        3jH2KdzhQedgTvEd/nBnwKYO5kkRDCqoCcD/YeKxd64Xs5+xDh6sKaogSG+QLbyjj1azZBlkc3jC
+        /RPxOBWd4pBsxGN0KKifDbCEl9D77O//87+gBgLs6gNrb0syKRQPLouvhjRm1e9Far/fF9xVKtsg
+        Ft/Rjr5d3IxnxtFXHSsGZo+pbNjDhiemOnuzCLYrsOfuw2EpJhyRZY8MEllGUEaRZsz/zpEYXjK0
+        bFPXGQp3ZcWALtGDOWXjoW3duNZ0RMr7qID15NkLd+U80Gz9LvCz9b/g/H8JwkKv1btARqxbKa/I
+        7JDmiVPKxqcYdXJAmTqdz4/9IobJtFTNc5C7iSoOgWJlDuvHYAooxB8L3lpb+0Ogu99rat8E23eW
+        ZT+BNJSVARQLqlVWAFZEVyxR7b3kB7UBSPiBwH7e7rS/B9hHAyiP32lPhJmsXcAX8YodrTMJUqFc
+        tDRT38GayY8G9vYfA+yXTa3/TdAOZbGtH9+e4W+pqBkn+9rW8aj49EYqiNd/ILRrnYvvgvaJ6c7m
+        qnHsr4Mmk5q+0hrZLwQ6yPjRoK41z/8YUO99G6Tf3dq2ev4M1qEQ3Z2UkQe0i/d+FLTrnfZ3QTv2
+        QlS9feyxn8RXAKFeKvAuelIq0X40lOt/DEL/Vsr83+rlt/P59e/i8+sfDen/5vP/P3xeado6G+YF
+        98XXAWz6PPlu6sd13/zyKKp8KW1ttaZ22cQ/tCscsJhMVOxaVhu0YsZjQym6kkbsv/AnLTdByIqJ
+        R0/+Vvl4GLNsMLxRcVs5Vhx0KjwGo4b8c05cS35C1Jr6yWjliyK4BUefNev/dvNHbPL9AzA8kbd4
+        NQAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out,
+        CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+      CMR-Hits:
+      - '1'
+      CMR-Request-Id:
+      - a07b210d-ecca-416b-add1-11c19546825b
+      CMR-Search-After:
+      - '[0.0,400.0,"GAMSSA_28km-ABOM-L4-GLOB-v01","1.0",2036881735,14]'
+      CMR-Took:
+      - '192'
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-MD5:
+      - 15e792da4f9de75fd32374aaff86772c
+      Content-SHA1:
+      - fcd5c45a5cde6557f88e58cf0fbbc41046a4365b
+      Content-Type:
+      - application/vnd.nasa.cmr.umm_results+json;version=1.18.4; charset=utf-8
+      Date:
+      - Fri, 10 Oct 2025 11:34:34 GMT
+      Server:
+      - ServerTokens ProductOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 ecac0584adf202eebfc7cd3800ff47ae.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - t8E4OWdRTORpPtcDZUqDcZEKOXiE-yMT8zfOS2xFngnKApt3fUwM8g==
+      X-Amz-Cf-Pop:
+      - MSP50-P2
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - t8E4OWdRTORpPtcDZUqDcZEKOXiE-yMT8zfOS2xFngnKApt3fUwM8g==
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/cassettes/test_xarray_backend/test_timeseries_statistics_image_size_limit.yaml
+++ b/tests/cassettes/test_xarray_backend/test_timeseries_statistics_image_size_limit.yaml
@@ -160,4 +160,164 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - earthaccess v0.11.0
+      authorization:
+      - DUMMY
+    method: GET
+    uri: https://cmr.earthdata.nasa.gov/search/collections.umm_json?has_granules=true&include_granule_counts=true&concept_id%5B%5D=C1996881146-POCLOUD&page_size=1
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/+1bjW7bSJJ+lYaA2XNgkRIp2bJ9t9ilJdlWVn8ryvbM7AyMFtm2mFCkhj92nCDA
+        vca93j3JfdVNSpREJ87Em8niFghiqdnsrq7+quqr6taHytxL4sqJUa0kYfgWH47r1YqXiAUa//Gh
+        shAJr5x8qETi3ou9MNA8t3LSPK5WXOGLRODLLfdjUa3chtGCJ5WTCl8ufc/hCTrX7gNXD3jMdWcR
+        6elisf8mDoNKtbKMwnvPFZEcrTIetfujyw7a5zzWnHAx8wKxGjiN83733r3HgyTrpyaElEmUohuP
+        49Dx5LQxCXzPI4/PfEHLqFyZdfPosGHWm6a2nm3d2ixtbe20Hh7Vm8cbrYZh1o2DplkvbTVLWw82
+        Ws1D8/Dg4LjVWLX+Wq1gzfeeo4S3TeOw2WqYDeNA+/Gnn2/Gk9EV3rTNo1azBamMw43mhtFqHR8d
+        HbZaxQGxub4cbdo3jfpR0zg+ahXlQLPZPDDrrcPDtTJ+/QhJGprvBW/lu8vQ5dzRwiV2KV2kfhpr
+        y3SG3a4NLifa63Ff6ze18/7oVLtv6kaNNrrkjShMhAPoPPHSr2p74yX2kvtanM5ikSRecJfvdIAH
+        90JB4vxiYtvT/b64F/5+cx8j7p/74Yz7+2dhGrgSDvu24Pt2Gt1yR+xPxWIpIp6kkdi3Au4/xl68
+        v0czv8pwlUQ8iAlc8QqCBWxpLgzC83cg9qHihIEjlomSqwxwH6tPdmo+p1Prc5020VnSaResn+j0
+        ScF3oVzSaRfZHzehvfVGKdB3xi3F/W6vEjP4WLCDre6lVrEzaKmRfCQrIeAU4KCAuvFu2zg+Pjw6
+        MozmYcHsVm4VUIXLq2AfD7T6gWYa0/rBiWmeNBr64bHxM7reAZepL+AfU/jAk6ODhpkBFpAOo1JT
+        ySVIHpc0uhP6PkwP82FtFfhjQnGHJ7zPg7uU31EfgberFStwPN/n0ePfxONDGLnS/JWxVWgLOYuV
+        QbFkbVB4Ig2RNckPqZ6lvRjslP7crmyUqe70h/EgXMAw6Wv+ERvXXsne9pLczWMb25HgSRhBcrgS
+        GpgNuty+nHRjNo7CN3gFA40C+DAxEXGYRo6gVffh09SC50myjE9qNeWq9DdLX4Wsu/C+lg+lkcBQ
+        2Zi8XTwX+XRDy7bIeXqJL1beiGVKkMIob8TOCiuF8jJvxAreiOXeiHQnIk/EQ754yUFHCeTOddfJ
+        vdiTWquyfIFVRrau1RuaYVTZi4jDVh53AhrBY9HJ4Z9PNK3XT+Q/vV6vE/yvRESGgk54c/3i2Oe0
+        oZXXIiHJl6lPvVifz2ASwMWjtHrLdT0SjPtWkkTeLE0y/5PpWPDIh8aTm8zIbuKER8lN4i0Irh0R
+        O5G3TNT03awvO1d9mU192RR9AeiIQQWQK9FJZu6nall1U6sfanUs63hzWWR9U2WdHWvanfYGXel3
+        MsF86KUglgjccqH6sl9BpHBZ6wbuZ6QyDYikmQdfKpXCJ5PftiXpqImYkyGNxapzoDrnk78UqguS
+        2tNJb3helHNMmIkTESSs13lS0u1euYjjUcey2tr5xflgojXPXteb5fMBX7YiK913NAq5l6yhHd5D
+        5juRvXExmvR+Hg2nVh8jXYSR9z4MEu5nnTvwdV5Ab5+LELwb2MXndgj364HzCPsRQi4olFiTadfu
+        WUOMckragsefwGThxHMyMgyjZJ4/Ww9ROSF2fw2olD3TjCM87fLyp/KhHabl42rHdRkIycf6KWnY
+        Ctxd2T9s7UHmbGizSUcnrP0IT+1GSCB8GHGi9cOgygq9lOM6YVCRH6osg3mBygXUZ8dPXeFK0Avu
+        zNnSeyd8aApvgLt5zgB/fJJkvQHY1HSRYeY6jHyX5Z2ZEpyBGNDud33fW8ah5+adz20mH9hi4Q34
+        mzCy3gGWJ4eN1pHRaBHiEMFIA2E0uj2DNQMgtFskbOXEPD7SzYOWaTYOP1Y35eFrRSpEBDAjZ92o
+        tvnHDuw7UH4Rxosk7qedlsvAo7SsIxwPsRQKvIsEUILd+ohJM4+RQXAilpGIgWGe7c8aah+LIRgb
+        glFiih9We9q76pIKgD+XRy6euSmibk6ebccTYCEFIgFQAxJ35JzhTjHDBbPbve6wTcNMw6XnoH3U
+        7lpDmxpEtMi/s2l3MO5OrCkilbRUxbikFzHIJLsWQxQ7s9rdra4KN8LNX0Hns9HlEN6tNxqyp94j
+        255m9EoZt5J/AlOTMYv8q2o6FXdeQHubN6/8/oHWMKamUfSwUD5GhqbAg2O8IxdA+9wjqkiA2nq2
+        5e0zrwmQ+374gE55WCbkMHuJvb7NcnDauM6oJ02P/lSMun5QP2zVNv2aBbsG/pLHAiNyQ08Pozsa
+        wcbDJAN9WdpGthHAY70oE1qzBMm71Hom4lZEBCil9nxCZjGkl4mnxfAcgs29u7kWrawFRDIbMrxl
+        d0qQp0lskeVNxALpKkQNaC/o9W5w70VhsKB4UdnS7ZbmatC1UTcOa2/0KBY62E1Lr+OfefxL9Ivc
+        GaV2MrS5B0c31QdVxl7r7Iq//y0V77V2imwprEJ+l3X1gc4s5KUJpr/b1MqaP7U0oy6JxjZ/gipy
+        UJLcY4Qlsl9kcZpxeCyh3vEi2HcHwVByJIzbW7tWWuUEIJcIRB7/gCiimbLicJo6b0UChz+akZ8e
+        R+LWe0do+aZVA7uBXMDFtsCRxda4B/6zDD2Kx6t94ZEz9+6FnnF90L5kTsxozfjjhrMepLI7aCeE
+        RLmDvJz0f//gk67VkbSKqCy2z72Mssw0YwtXve41m3T7IGAd1huejSYD6a1KiQy7jIVESc7w2Xnq
+        IdAh7aFlQNI2QgumzgYvYIdWgYWms2TF+CzW7k2Vazy/7HW6/d6wa6thPpMxYXrYiaJOkoptinoe
+        helSxuYLWChbx7MnnUERgc9Zx+eVt17peXcIT99nnVH7ctAdTvMem8u8m0dxnGwss2RlF6BsS9iU
+        XBxSLZk6rbOqpaIwz9uLl19DCRhF7MY1J4SmE08W1JYU1Pkiri2QWEH1+JBGGpZeslpyV+St9Cob
+        eCBFt7dsop/hW59H0MG1fq6zPeP4+OiVzk45XKfyy1XlmB/4vQjSxUxEG14YgQy8zRO+G7PbKFww
+        rnz6E34cI4JORUSVhUpwdPYaCT660GMrWYTxck60SRrGyBE8wOepcOYByOPdY5UZByes1TS01mHj
+        xTdmfHna77Vl+6bpYDveKDFjHT4yiUNHBgsEjRqfxTJoGK2DmnFgwpM3zcMfzCNS5Q/mMdLjHxrt
+        OkQ+ObUvrm37h0bX1Ot6e/SfZskubTgrhn+Ey/OOze5VMs1MpoyLxRuU4aVVcWl3J/9hK1eyA83P
+        u82ScOCGTpwZZi1ciqAmG7A0sx4d6Ev3tsz3KA4tkcIiwV0o4cWXKp3npNvujXdXeucl83Smw+ay
+        JdVIFC0XpdzKQArCeO6FsDNnzoVfBcbJxEoZgvsAAs6KNEF/MWKks4wLxWsuJApciHjFHhGQVycs
+        IxX6tzOqZ7GuMlAoopplmOxBzGIvEX+Al4b8Dw8PehZsFO3eiTHT6diG0hWvWdV12CwKH7Lw74YP
+        gR9yt2wFRWK3sYTzLjIHAHcTyT3AGO2j62F/ZHV2tE1HeiXGCkAkKfc1V3JJ5Hi1ddU5rpVUwZnM
+        zRMiMUQxz/JzxEAk7c6Z1mSOz5EIOeg2QFqViVw8ZXynoa8Dm4f43ns8bdTrq7x3cFr5uKvJU6Wx
+        rK5GkIcXglOIYSoxQ2zr5isjYoJnX6/P8hEpdck1qqQoJY7ySS0TN/7L8s/fRpGtzyqSMrvceOYZ
+        BfqDOM4zCvjb0r9Ol49EHvD/HM4wgHubheFbloTMCTVZYBIyeSXTGow6PZv1zTGL0QzSg2dyPx/g
+        1xlc7l3IiOh4SarayT6dKIzpaMj33H9ObP2ygJOkMEnKPmozOPvagsdYfi1fd1yzr0dTrWtpVBuu
+        tVWJTdys1nvjBbS8m5C4lO4tH4NZiVbt0XTE9uyElIcgQaRDkq9X7MqL4Ru890+qYqPDjk3lurjq
+        2ZdWv/fzrjZo6h01xGES7tALxw9Tdw2Uv/h/VqHgpt+8wY7fwEhvsnzkppCPVE/9VAx4NPPFjT1H
+        4HaRvXni9uaUJ/NHWbWttkOoVWZeN8bBokRBV8pHKpRQCTrKixqgv75KIW69KE6YKxzMQVokFMKj
+        hojvcE+vbaRme+IdxPIkw/NfPc9D/dO4V1lafpPd5XDBOG717O7Hp3zkVW8yxc6y9qjfR/Ch3SXt
+        faXnLRl1O4X++h0ZW5O/X2L2sk35ozS+5NFv+ntvKZX4DDva1Ml0jhQt4J7/TEP9vDceZ04oH7h8
+        DXjnTpWjoBcqbG1URdqTLmRXJzFZyatJJa+GMTUOEflPGi0dydLPxTVfjjvb77SQWWnmEZ2y142T
+        5kFel61WrBmwxamAXbHYl9cr9pQbebWqfT5Bp9fMeykL5sJlPGaUmIC3UzpGOXl+bMf2bpEx4tsj
+        o1JR4Dy+kiEpAH4of/A1OhVc9w4DsdU5kW6YjnTHc8xKxyvSJ1PKv5w/MqrXsFTyesrOfaSlJM+M
+        k4S3aaD4GwGdI5MEROgsASRURMvQV/klmEQU0okLfc6TCTqDgM3QmQPYlufqbAo58vyzyQaUm6jU
+        5NKH3udbat4DQqDL5lpdnpQK6kqXFLLRP5GLz0vOFJ/fSjldRjci6DM9CGd080TdHFDlhVjQ6Rwt
+        AzsuE+U4Oz8iNaxqOJZ7zwPaH2RgoI3QDrMdLmv9bMJdTxUgtO7IZnvWwJ5o3VdVpW3rx+e+jUyc
+        Snbt0UC7NtTbdE4VUQgtaKO34Hf0IlX4AZNo9X4MRRE9eZVn+Ury31Iu9TAVUcTZEhslLzapCS5t
+        NuT3j2yxEuzaC1wbUFmPq3qu1nAloscdSyisYs+6uphMpBC5cocjy1oTplglqtgSSZPK90XKT695
+        f0/5Ii+dKeR4sCJ5qyUAWOT00mVzGNTq3czHxjnquyCNU9uaKsRLAch6exjKXjE5a82D2Rl3PDQ+
+        sr2R3WO2dfZKLbqPx0kK778+nWFtQUYgByUhQK1C2FF2AInZvAVddsR3WiscMpeayhznqlgo03I/
+        Gz7WmVxrbs5yTIdOBoFUxld3GdjqxpEcJ8Ym5BlNEci8eKsGthh5JE5WYKMg5viw5kSWxOQ6SKD8
+        UhFzEWpp84kT0wNyOXTVoDdhWZ1QZv+bx636dA4zzeVXHoQOZWeP5aVRqjuyPZblwSVBEd6PLoYu
+        UuQilFFmnzRZQInlGe1u/VLLi67slYKdQ3eFlBgcK8ScvvrWifRVmUVnsrgp9QN/qbMedsCdgw3E
+        uQ6Kh20FKGycuyEQdGCOn660Yaepbk9jSpqROU26dCth/UsFeqQk+uSXCtCcXV0hMVxC0QKRnnm3
+        5G2zRBaqXsUE6RWxLRsRhUoy/ezg/Kkj2fPu6HxijS96bTCFc0UNcvaAIG31ZZwcZEI+I0LTPZOm
+        Vm9lEXp1CvqpCG025Mlpnd5pmoWT092rQOO8tk5CFE8qVxfW+mFwl7d9aUSXUxL5ASegqyL52fsk
+        zC4XZwfcLOtDR1FnRBWzCRWuZNLtur7ID1G9t/K+HF/1I9ShZSgP87hyK9YtYOHlh/HSbJ6+6LSS
+        cuvQLmsdCGfOAy9ebGxWd6EIXn7pJZHS6gsdLjT46+aZx68fc1ampNvSgzVpX/SuuhN5FlfYBRK7
+        BkuqZadCG9vxBBvJ+T3M01JMyFJOPfO31af1UM1v5b2ANhSJ/WsJl5Wo2D64281TVrrayFIuRoMu
+        Eobz3Yy9jDWrG6aZ3BK+W4qXfiiLQwUQyq6Zmi+Ev2Sg92+/I72oCb9SMaSbgirGk1G7a9ujJ0G4
+        ib7/PyBaeHEsrw2RzooaA2mcTnqnl9OndfZvw/0afK5vEBXvUl+A0YCNaey/QCM8dcV5nPPzjZUR
+        GWKjNUlec1Z5P6GwX0T3Nzep+LJkKJIpVVnWsz3nlOmCEcaJ52zciB1FM4/CnRe6O4WBobzS5rOl
+        fEylEGS4S4RNJ+K3yf/+9//EjPgQ6Egk7vPoGqrMkYalV30eiOJl1OMjna4h5bVmL0jV+gr3Lc/6
+        I2tavN7ZA8Wlu3XysiGm2xHUXgnF6IK7z6M1nZX8bkMcSOvLn5bkNK8LLQGYW2IaazHzu3RlYmI/
+        e+u8coeayGxtc7PyhE97TsL36d2zH3gyv/bcZP4NdGI2GiBna638zfOzpLRcMbSDG7CVOfOmLp6f
+        c39HijCaB1+miF8LDPgL7Lw9mvRG/W34tENYoy8vRX9Hdm3UDf3wX8OwWy9i2Ne9Yce2tpKOrLDy
+        PWHVrH8TrMrK0/OCkipS7VkDTd75/I5ADHAc/Wtg2Px3cPrK4PQ7cU71Ss043lTakGeFuvzu2Z82
+        bqVZLqBKhFn9slS+/R2h3qibumH+a+C+1XwR4MvytdZ4got8pvot3/tucN/8Nv49O7LYqrGpMiZ0
+        EdyJjXEGKg1lRpxo1/yzruLbQ35Dad8z4qW3eAHEg3ybv4d7M/M7QvtXMe8e4E2HUdJJa+pscZ2K
+        b8L99HL0E0XGT6m0M+mdTXvDc6Y6q9/65NXyzd/mnHzYvlTnBmV3AtLFonCNrnZv6IbKl7MpLwcD
+        jeoz68p41oN+YqLqL1bgfuKHHWeeL7KOG0/+UXKPDPOotkx/Q7k7aLXUjx1prML1sa3W9W0y+q1X
+        Qr+RzNeVd5E/pVodBKx/Olvf/AlVVUr95KK+Z9E/Ut3y/wB/m7cbe0UAAA==
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out,
+        CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+      CMR-Hits:
+      - '1'
+      CMR-Request-Id:
+      - 2884ccb7-6f1f-4a70-9239-9975d9cea168
+      CMR-Search-After:
+      - '[0.0,3600.0,"MUR-JPL-L4-GLOB-v4.1","4.1",1996881146,49]'
+      CMR-Took:
+      - '191'
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-MD5:
+      - 2b032255d7e5b39d05bdd4798874c6fa
+      Content-SHA1:
+      - 67abf2c7d498de310402a5ba440086b3773b7ec7
+      Content-Type:
+      - application/vnd.nasa.cmr.umm_results+json;version=1.18.4; charset=utf-8
+      Date:
+      - Fri, 10 Oct 2025 11:34:35 GMT
+      Server:
+      - ServerTokens ProductOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 7e35f09412049c9a6642645fafc6cabe.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - eWwMi7s72LI15eCmDdWK-Pr6rg6jvi0AXgqGJG3AKj_aVNYYq6AcVQ==
+      X-Amz-Cf-Pop:
+      - MSP50-P2
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - eWwMi7s72LI15eCmDdWK-Pr6rg6jvi0AXgqGJG3AKj_aVNYYq6AcVQ==
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -201,7 +201,7 @@ class TestRasterioCompatibility:
 class TestConceptCompatibility:
     """Test evaluate_concept_compatibility function."""
 
-    @patch("titiler.cmr.utils.get_concept_id_umm")
+    @patch("titiler.cmr.compatibility.get_concept_id_umm")
     @patch("titiler.cmr.compatibility.evaluate_rasterio_compatibility")
     @patch("titiler.cmr.compatibility.evaluate_xarray_compatibility")
     def evaluate_xarray_succeeds(self, mock_xarray, mock_rasterio, mock_get_umm):
@@ -232,7 +232,7 @@ class TestConceptCompatibility:
         mock_xarray.assert_called_once()
         mock_rasterio.assert_not_called()
 
-    @patch("titiler.cmr.utils.get_concept_id_umm")
+    @patch("titiler.cmr.compatibility.get_concept_id_umm")
     @patch("titiler.cmr.compatibility.evaluate_rasterio_compatibility")
     @patch("titiler.cmr.compatibility.evaluate_xarray_compatibility")
     def test_fallback_to_rasterio(self, mock_xarray, mock_rasterio, mock_get_umm):
@@ -264,7 +264,7 @@ class TestConceptCompatibility:
         mock_xarray.assert_called_once()
         mock_rasterio.assert_called_once()
 
-    @patch("titiler.cmr.utils.get_concept_id_umm")
+    @patch("titiler.cmr.compatibility.get_concept_id_umm")
     @patch("titiler.cmr.compatibility.evaluate_rasterio_compatibility")
     @patch("titiler.cmr.compatibility.evaluate_xarray_compatibility")
     def test_both_fail(self, mock_xarray, mock_rasterio, mock_get_umm):
@@ -288,4 +288,4 @@ class TestConceptCompatibility:
             evaluate_concept_compatibility("C1234-TEST", mock_request, mock_auth)
 
         assert exc_info.value.status_code == 400
-        assert "cannot parse concept_id" in str(exc_info.value.detail)
+        assert "cannot parse concept_id" in exc_info.value.detail

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,0 +1,291 @@
+"""Test titiler.cmr.compatibility module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from titiler.cmr.compatibility import (
+    evaluate_concept_compatibility,
+    evaluate_rasterio_compatibility,
+    evaluate_xarray_compatibility,
+    extract_xarray_metadata,
+)
+
+
+class TestExtractXarrayMetadata:
+    """Test extract_xarray_metadata function."""
+
+    def test_extract_basic_metadata(self):
+        """Test extracting metadata from a simple dataset."""
+        # Mock xarray dataset
+        mock_ds = MagicMock()
+
+        # Mock data variables
+        mock_var = MagicMock()
+        mock_var.shape = (365, 1800, 3600)
+        mock_var.dtype = "float32"
+        mock_ds.data_vars = ["temperature"]
+        mock_ds.__getitem__ = lambda self, key: mock_var
+
+        # Mock coordinates
+        mock_coord = MagicMock()
+        mock_coord.size = 365
+        mock_coord.dtype.kind = "f"
+        mock_coord.min.return_value = 0.0
+        mock_coord.max.return_value = 364.0
+
+        # Create a proper mock for coords
+        mock_coords = MagicMock()
+        mock_coords.__getitem__ = lambda self, key: mock_coord
+        mock_coords.items.return_value = [("time", mock_coord)]
+        mock_ds.coords = mock_coords
+
+        # Mock dims
+        mock_ds.dims = {"time": 365, "lat": 1800, "lon": 3600}
+
+        result = extract_xarray_metadata(mock_ds)
+
+        assert result["backend"] == "xarray"
+        assert "temperature" in result["variables"]
+        assert result["variables"]["temperature"]["shape"] == [365, 1800, 3600]
+        assert result["variables"]["temperature"]["dtype"] == "float32"
+        assert result["dimensions"] == {"time": 365, "lat": 1800, "lon": 3600}
+        assert "time" in result["coordinates"]
+        assert result["coordinates"]["time"]["size"] == 365
+
+    def test_extract_metadata_with_non_numeric_coord(self):
+        """Test extracting metadata with non-numeric coordinate."""
+        mock_ds = MagicMock()
+
+        # Mock data variables
+        mock_var = MagicMock()
+        mock_var.shape = (10,)
+        mock_var.dtype = "float32"
+        mock_ds.data_vars = ["data"]
+        mock_ds.__getitem__ = lambda self, key: mock_var
+
+        # Mock string coordinate (no min/max)
+        mock_coord = MagicMock()
+        mock_coord.size = 10
+        mock_coord.dtype.kind = "U"  # Unicode string
+
+        # Create a proper mock for coords
+        mock_coords = MagicMock()
+        mock_coords.__getitem__ = lambda self, key: mock_coord
+        mock_coords.items.return_value = [("labels", mock_coord)]
+        mock_ds.coords = mock_coords
+        mock_ds.dims = {"labels": 10}
+
+        result = extract_xarray_metadata(mock_ds)
+
+        # Non-numeric coordinates shouldn't have min/max
+        assert "min" not in result["coordinates"]["labels"]
+        assert "max" not in result["coordinates"]["labels"]
+
+
+class TestXarrayCompatibility:
+    """Test evaluate_xarray_compatibility function."""
+
+    @patch("titiler.cmr.compatibility.CMRBackend")
+    @patch("titiler.cmr.compatibility.xarray_open_dataset")
+    def test_xarray_success(self, mock_xarray_open, mock_backend):
+        """Test successful xarray compatibility check."""
+        # Mock request
+        mock_request = MagicMock()
+        mock_request.app.state.cmr_auth = None
+
+        # Mock auth config
+        mock_auth = MagicMock()
+        mock_auth.access = "external"
+
+        # Mock backend and assets
+        mock_backend_instance = MagicMock()
+        mock_backend.return_value.__enter__ = MagicMock(
+            return_value=mock_backend_instance
+        )
+        mock_backend.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_backend_instance.assets_for_tile.return_value = [
+            {"url": "s3://bucket/file.zarr"}
+        ]
+
+        # Mock xarray dataset
+        mock_ds = MagicMock()
+        mock_var = MagicMock()
+        mock_var.shape = (10, 20)
+        mock_var.dtype = "float32"
+        mock_ds.data_vars = ["temp"]
+        mock_ds.__getitem__ = lambda self, key: mock_var
+
+        # Create a proper mock for coords
+        mock_coords = MagicMock()
+        mock_coords.items.return_value = []
+        mock_ds.coords = mock_coords
+        mock_ds.dims = {"x": 10, "y": 20}
+
+        mock_xarray_open.__enter__ = MagicMock(return_value=mock_ds)
+        mock_xarray_open.__exit__ = MagicMock(return_value=False)
+        mock_xarray_open.return_value = mock_xarray_open
+
+        result = evaluate_xarray_compatibility("C1234-TEST", mock_request, mock_auth)
+
+        assert result["backend"] == "xarray"
+        assert result["example_assets"] == "s3://bucket/file.zarr"
+        assert "temp" in result["variables"]
+
+    @patch("titiler.cmr.compatibility.CMRBackend")
+    def test_xarray_no_assets(self, mock_backend):
+        """Test xarray compatibility with no assets found."""
+        mock_request = MagicMock()
+        mock_request.app.state.cmr_auth = None
+        mock_auth = MagicMock()
+
+        # Mock backend returning empty assets
+        mock_backend_instance = MagicMock()
+        mock_backend.return_value.__enter__ = MagicMock(
+            return_value=mock_backend_instance
+        )
+        mock_backend.return_value.__exit__ = MagicMock(return_value=False)
+        mock_backend_instance.assets_for_tile.return_value = []
+
+        with pytest.raises(ValueError, match="No assets found"):
+            evaluate_xarray_compatibility("C1234-TEST", mock_request, mock_auth)
+
+
+class TestRasterioCompatibility:
+    """Test evaluate_rasterio_compatibility function."""
+
+    @patch("titiler.cmr.compatibility.CMRBackend")
+    def evaluate_rasterio_success(self, mock_backend):
+        """Test successful rasterio compatibility check."""
+        mock_request = MagicMock()
+        mock_request.app.state.cmr_auth = None
+        mock_auth = MagicMock()
+        mock_auth.access = "external"
+
+        # Mock backend and assets
+        mock_backend_instance = MagicMock()
+        mock_backend.return_value.__enter__ = MagicMock(
+            return_value=mock_backend_instance
+        )
+        mock_backend.return_value.__exit__ = MagicMock(return_value=False)
+        mock_backend_instance.assets_for_tile.return_value = [
+            {"url": "s3://bucket/file.tif"}
+        ]
+
+        result = evaluate_rasterio_compatibility("C1234-TEST", mock_request, mock_auth)
+
+        assert result["backend"] == "rasterio"
+        assert result["example_assets"] == "s3://bucket/file.tif"
+
+    @patch("titiler.cmr.compatibility.CMRBackend")
+    def evaluate_rasterio_no_assets(self, mock_backend):
+        """Test rasterio compatibility with no assets found."""
+        mock_request = MagicMock()
+        mock_request.app.state.cmr_auth = None
+        mock_auth = MagicMock()
+
+        # Mock backend returning empty assets
+        mock_backend_instance = MagicMock()
+        mock_backend.return_value.__enter__ = MagicMock(
+            return_value=mock_backend_instance
+        )
+        mock_backend.return_value.__exit__ = MagicMock(return_value=False)
+        mock_backend_instance.assets_for_tile.return_value = []
+
+        with pytest.raises(ValueError, match="No assets found"):
+            evaluate_rasterio_compatibility("C1234-TEST", mock_request, mock_auth)
+
+
+class TestConceptCompatibility:
+    """Test evaluate_concept_compatibility function."""
+
+    @patch("titiler.cmr.utils.get_concept_id_umm")
+    @patch("titiler.cmr.compatibility.evaluate_rasterio_compatibility")
+    @patch("titiler.cmr.compatibility.evaluate_xarray_compatibility")
+    def evaluate_xarray_succeeds(self, mock_xarray, mock_rasterio, mock_get_umm):
+        """Test when xarray compatibility succeeds."""
+        mock_request = MagicMock()
+        mock_auth = MagicMock()
+
+        # Mock metadata response
+        mock_get_umm.return_value = {
+            "umm": {
+                "TemporalExtents": [
+                    {"RangeDateTimes": [{"BeginningDateTime": "2020-01-01T00:00:00Z"}]}
+                ]
+            }
+        }
+
+        mock_xarray.return_value = {
+            "backend": "xarray",
+            "example_assets": "s3://test.zarr",
+        }
+
+        result = evaluate_concept_compatibility("C1234-TEST", mock_request, mock_auth)
+
+        assert result.backend == "xarray"
+        assert result.concept_id == "C1234-TEST"
+        assert result.datetime is not None
+        mock_get_umm.assert_called_once_with("C1234-TEST")
+        mock_xarray.assert_called_once()
+        mock_rasterio.assert_not_called()
+
+    @patch("titiler.cmr.utils.get_concept_id_umm")
+    @patch("titiler.cmr.compatibility.evaluate_rasterio_compatibility")
+    @patch("titiler.cmr.compatibility.evaluate_xarray_compatibility")
+    def test_fallback_to_rasterio(self, mock_xarray, mock_rasterio, mock_get_umm):
+        """Test fallback to rasterio when xarray fails."""
+        mock_request = MagicMock()
+        mock_auth = MagicMock()
+
+        # Mock metadata response
+        mock_get_umm.return_value = {
+            "umm": {
+                "TemporalExtents": [
+                    {"RangeDateTimes": [{"BeginningDateTime": "2020-01-01T00:00:00Z"}]}
+                ]
+            }
+        }
+
+        mock_xarray.side_effect = ValueError("No assets found")
+        mock_rasterio.return_value = {
+            "backend": "rasterio",
+            "example_assets": "s3://test.tif",
+        }
+
+        result = evaluate_concept_compatibility("C1234-TEST", mock_request, mock_auth)
+
+        assert result.backend == "rasterio"
+        assert result.concept_id == "C1234-TEST"
+        assert result.datetime is not None
+        mock_get_umm.assert_called_once_with("C1234-TEST")
+        mock_xarray.assert_called_once()
+        mock_rasterio.assert_called_once()
+
+    @patch("titiler.cmr.utils.get_concept_id_umm")
+    @patch("titiler.cmr.compatibility.evaluate_rasterio_compatibility")
+    @patch("titiler.cmr.compatibility.evaluate_xarray_compatibility")
+    def test_both_fail(self, mock_xarray, mock_rasterio, mock_get_umm):
+        """Test when both readers fail."""
+        mock_request = MagicMock()
+        mock_auth = MagicMock()
+
+        # Mock metadata response
+        mock_get_umm.return_value = {
+            "umm": {
+                "TemporalExtents": [
+                    {"RangeDateTimes": [{"BeginningDateTime": "2020-01-01T00:00:00Z"}]}
+                ]
+            }
+        }
+
+        mock_xarray.side_effect = ValueError("Xarray failed")
+        mock_rasterio.side_effect = OSError("Rasterio failed")
+
+        with pytest.raises(HTTPException) as exc_info:
+            evaluate_concept_compatibility("C1234-TEST", mock_request, mock_auth)
+
+        assert exc_info.value.status_code == 400
+        assert "cannot parse concept_id" in str(exc_info.value.detail)

--- a/titiler/cmr/compatibility.py
+++ b/titiler/cmr/compatibility.py
@@ -5,12 +5,14 @@ from typing import Any, Dict, List, Literal, Optional
 from fastapi import HTTPException
 from pydantic import BaseModel
 from rio_tiler.constants import WEB_MERCATOR_TMS
+from rio_tiler.io.rasterio import Reader
+from rio_tiler.models import Info
 from starlette.requests import Request
 
 from titiler.cmr.backend import CMRBackend
 from titiler.cmr.dependencies import ConceptID
 from titiler.cmr.logger import logger
-from titiler.cmr.reader import MultiFilesBandsReader, xarray_open_dataset
+from titiler.cmr.reader import xarray_open_dataset
 from titiler.cmr.settings import AuthSettings
 from titiler.cmr.utils import get_concept_id_umm
 from titiler.xarray.io import Reader as XarrayReader
@@ -26,6 +28,7 @@ class CompatibilityResponse(BaseModel):
     dimensions: Optional[Dict[str, int]] = None
     coordinates: Optional[Dict[str, Dict[str, Any]]] = None
     example_assets: Optional[Dict[str, str] | str] = None
+    sample_asset_raster_info: Optional[Info] = None
 
 
 def extract_xarray_metadata(ds: Any) -> Dict[str, Any]:
@@ -140,7 +143,7 @@ def evaluate_rasterio_compatibility(
 
     with CMRBackend(
         tms=WEB_MERCATOR_TMS,
-        reader=MultiFilesBandsReader,
+        reader=Reader,
         reader_options={"bands": [1]},
         auth=request.app.state.cmr_auth,
     ) as src_dst:
@@ -157,8 +160,16 @@ def evaluate_rasterio_compatibility(
         if not assets:
             raise ValueError("No assets found for MultiFilesBandsReader")
 
+        example_assets: Dict[str, str] = assets[0]["url"]
+
+        with src_dst.reader(
+            input=list(example_assets.values())[0], tms=src_dst.tms
+        ) as _src_dst:
+            info = _src_dst.info()
+
         return {
-            "example_assets": assets[0]["url"],
+            "example_assets": example_assets,
+            "sample_asset_raster_info": info,
             "backend": "rasterio",
         }
 

--- a/titiler/cmr/compatibility.py
+++ b/titiler/cmr/compatibility.py
@@ -1,0 +1,214 @@
+"""titiler.cmr.compatibility: Compatibility testing utilities."""
+
+from typing import Any, Dict, List, Literal, Optional
+
+from fastapi import HTTPException
+from pydantic import BaseModel
+from rio_tiler.constants import WEB_MERCATOR_TMS
+from starlette.requests import Request
+
+from titiler.cmr.backend import CMRBackend
+from titiler.cmr.dependencies import ConceptID
+from titiler.cmr.logger import logger
+from titiler.cmr.reader import MultiFilesBandsReader, xarray_open_dataset
+from titiler.cmr.settings import AuthSettings
+from titiler.cmr.utils import get_concept_id_umm
+from titiler.xarray.io import Reader as XarrayReader
+
+
+class CompatibilityResponse(BaseModel):
+    """Compatibility endpoint response model"""
+
+    concept_id: ConceptID
+    backend: Literal["rasterio", "xarray"]
+    datetime: List[Dict[str, Any]]
+    variables: Optional[Dict[str, Dict[str, Any]]] = None
+    dimensions: Optional[Dict[str, int]] = None
+    coordinates: Optional[Dict[str, Dict[str, Any]]] = None
+    example_assets: Optional[Dict[str, str] | str] = None
+
+
+def extract_xarray_metadata(ds: Any) -> Dict[str, Any]:
+    """Extract comprehensive metadata from an xarray Dataset.
+
+    Args:
+        ds: xarray Dataset instance
+
+    Returns:
+        Dictionary containing variables, dimensions, and coordinates metadata
+    """
+    variables = {
+        var: {
+            "shape": list(ds[var].shape),
+            "dtype": str(ds[var].dtype),
+        }
+        for var in ds.data_vars
+    }
+
+    coordinates = {}
+    for coord, coord_data in ds.coords.items():
+        coord_info = {
+            "size": int(coord_data.size),
+            "dtype": str(coord_data.dtype),
+        }
+
+        if coord_data.dtype.kind in ["i", "f", "u"]:
+            try:
+                coord_info["min"] = float(coord_data.min())
+                coord_info["max"] = float(coord_data.max())
+            except Exception:
+                pass
+        coordinates[coord] = coord_info
+
+    return {
+        "variables": variables,
+        "dimensions": dict(ds.dims),
+        "coordinates": coordinates,
+        "backend": "xarray",
+    }
+
+
+def evaluate_xarray_compatibility(
+    concept_id: ConceptID,
+    request: Request,
+    s3_auth_config: AuthSettings,
+) -> Dict[str, Any]:
+    """Test XarrayReader compatibility with a concept.
+
+    Args:
+        concept_id: CMR concept ID to test
+        request: FastAPI request object
+        s3_auth_config: S3 authentication configuration
+
+    Returns:
+        Dictionary with xarray compatibility information
+
+    Raises:
+        ValueError: If no assets found or reader incompatible
+        HTTPException: If CMR query fails
+        OSError: If file access fails
+        KeyError: If expected data structure is missing
+    """
+    logger.info("Testing XarrayReader")
+
+    with CMRBackend(
+        tms=WEB_MERCATOR_TMS,
+        reader=XarrayReader,
+        reader_options={},
+        auth=request.app.state.cmr_auth,
+    ) as src_dst:
+        assets = src_dst.assets_for_tile(
+            0,
+            0,
+            0,
+            limit=1,
+            concept_id=concept_id,
+            access=s3_auth_config.access,
+        )
+
+        if not assets:
+            raise ValueError("No assets found for XarrayReader")
+
+        with xarray_open_dataset(assets[0]["url"]) as ds:
+            result = extract_xarray_metadata(ds)
+            result["example_assets"] = assets[0]["url"]
+            return result
+
+
+def evaluate_rasterio_compatibility(
+    concept_id: ConceptID,
+    request: Request,
+    s3_auth_config: AuthSettings,
+) -> Dict[str, Any]:
+    """Test MultiFilesBandsReader compatibility with a concept.
+
+    Args:
+        concept_id: CMR concept ID to test
+        request: FastAPI request object
+        s3_auth_config: S3 authentication configuration
+
+    Returns:
+        Dictionary with rasterio compatibility information
+
+    Raises:
+        ValueError: If no assets found or reader incompatible
+        HTTPException: If CMR query fails
+        OSError: If file access fails
+        KeyError: If expected data structure is missing
+    """
+    logger.info("Testing MultiFilesBandsReader")
+
+    with CMRBackend(
+        tms=WEB_MERCATOR_TMS,
+        reader=MultiFilesBandsReader,
+        reader_options={"bands": [1]},
+        auth=request.app.state.cmr_auth,
+    ) as src_dst:
+        assets = src_dst.assets_for_tile(
+            0,
+            0,
+            0,
+            limit=1,
+            concept_id=concept_id,
+            access=s3_auth_config.access,
+            bands_regex=".*",
+        )
+
+        if not assets:
+            raise ValueError("No assets found for MultiFilesBandsReader")
+
+        return {
+            "example_assets": assets[0]["url"],
+            "backend": "rasterio",
+        }
+
+
+def evaluate_concept_compatibility(
+    concept_id: ConceptID,
+    request: Request,
+    s3_auth_config: AuthSettings,
+) -> CompatibilityResponse:
+    """Test which reader backend is compatible with a CMR concept.
+
+    Tries XarrayReader first, falls back to MultiFilesBandsReader.
+    Also fetches and includes CMR metadata in the response.
+
+    Args:
+        concept_id: CMR concept ID to test
+        request: FastAPI request object
+        s3_auth_config: S3 authentication configuration
+
+    Returns:
+        CompatibilityResponse with backend info, temporal extent, and metadata
+
+    Raises:
+        HTTPException: If neither reader is compatible or metadata cannot be fetched
+    """
+
+    metadata = get_concept_id_umm(concept_id)
+    temporal_extent = metadata["umm"]["TemporalExtents"]
+
+    # Try xarray first
+    try:
+        result = evaluate_xarray_compatibility(concept_id, request, s3_auth_config)
+        return CompatibilityResponse(
+            concept_id=concept_id,
+            datetime=temporal_extent,
+            **result,
+        )
+    except (ValueError, HTTPException, OSError, KeyError) as e:
+        logger.warning(f"XarrayReader failed: {e}")
+
+    # Fall back to rasterio
+    try:
+        result = evaluate_rasterio_compatibility(concept_id, request, s3_auth_config)
+        return CompatibilityResponse(
+            concept_id=concept_id,
+            datetime=temporal_extent,
+            **result,
+        )
+    except (ValueError, HTTPException, OSError, KeyError) as e:
+        logger.warning(f"MultiFilesBandsReader failed: {e}")
+
+    # Both failed
+    raise HTTPException(400, f"cannot parse concept_id {concept_id}")

--- a/titiler/cmr/factory.py
+++ b/titiler/cmr/factory.py
@@ -26,7 +26,12 @@ from typing_extensions import Annotated
 
 from titiler.cmr import models
 from titiler.cmr.backend import CMRBackend
+from titiler.cmr.compatibility import (
+    CompatibilityResponse,
+    evaluate_concept_compatibility,
+)
 from titiler.cmr.dependencies import (
+    ConceptID,
     InterpolatedXarrayParams,
     OutputType,
     RasterioParams,
@@ -37,6 +42,8 @@ from titiler.cmr.dependencies import (
 from titiler.cmr.enums import MediaType
 from titiler.cmr.logger import logger
 from titiler.cmr.reader import MultiFilesBandsReader, xarray_open_dataset
+from titiler.cmr.settings import AuthSettings
+from titiler.cmr.utils import get_concept_id_umm
 from titiler.core.algorithm import algorithms as available_algorithms
 from titiler.core.dependencies import (
     CoordCRSParams,
@@ -65,6 +72,8 @@ jinja2_env = jinja2.Environment(
 DEFAULT_TEMPLATES = Jinja2Templates(env=jinja2_env)
 
 MOSAIC_THREADS = int(os.getenv("MOSAIC_CONCURRENCY", MAX_THREADS))
+
+s3_auth_config = AuthSettings()
 
 
 def create_html_response(
@@ -217,6 +226,7 @@ class Endpoints(TilerFactory):
         self.register_landing()
         self.register_conformance()
         self.register_tilematrixsets()
+        self.register_info()
         self.register_tiles()
         self.register_map()
         self.register_statistics()
@@ -444,6 +454,57 @@ class Endpoints(TilerFactory):
                 )
 
             return data
+
+    def register_info(self):  # noqa: C901
+        """Register /concept_metadata and /compatibility endpoints"""
+
+        @self.router.get(
+            "/concept_metadata",
+            tags=["Metadata"],
+        )
+        def concept_metadata_endpoint(
+            request: Request,
+            concept_id: ConceptID,
+        ) -> Dict[str, Any]:
+            return get_concept_id_umm(concept_id)
+
+        @self.router.get(
+            "/compatibility",
+            tags=["Metadata"],
+            description=(
+                "Analyzes a CMR dataset to determine the optimal reader backend and extract metadata "
+                "needed for data access requests. This endpoint:\n\n"
+                "**Under the hood:**\n"
+                "- Tests the dataset with XarrayReader first (for multidimensional NetCDF/Zarr data)\n"
+                "- Falls back to a rasterio reader if needed\n"
+                "- Fetches CMR metadata including temporal extent and collection information\n"
+                "- Probes the first available data asset to extract structural metadata\n\n"
+                "**Returns:**\n"
+                "- `backend`: Which reader to use ('xarray' or 'rasterio')\n"
+                "- `datetime`: Temporal extent(s) of the dataset\n"
+                "- `variables`: Available data variables with shape and dtype (xarray only)\n"
+                "- `dimensions`: Dimension names and sizes (xarray only)\n"
+                "- `coordinates`: Coordinate information with ranges (xarray only)\n"
+                "- `example_assets`: Sample data URL from the collection\n\n"
+                "**Use this information to:**\n"
+                "- Set `backend` parameter for /tiles, /bbox, and /feature endpoints\n"
+                "- Choose valid `variable` names for xarray datasets\n"
+                "- Identify available dimensions for selection/interpolation\n"
+                "- Determine temporal coverage for time-based queries\n"
+                "- Understand data structure before making tile/image requests"
+            ),
+            response_model_exclude_none=True,
+        )
+        def compatibility_endpoint(
+            request: Request,
+            concept_id: ConceptID,
+        ) -> CompatibilityResponse:
+            """Test which reader backend is compatible with a CMR concept."""
+            return evaluate_concept_compatibility(
+                concept_id=concept_id,
+                request=request,
+                s3_auth_config=s3_auth_config,
+            )
 
     def register_tiles(self):  # noqa: C901
         """Register tileset endpoints."""

--- a/titiler/cmr/utils.py
+++ b/titiler/cmr/utils.py
@@ -7,7 +7,7 @@ Code from titiler.pgstac, MIT License.
 import logging
 import time
 from datetime import datetime
-from typing import Any, List, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
 
 import earthaccess
 from geojson_pydantic import Feature, FeatureCollection
@@ -16,6 +16,7 @@ from rasterio.crs import CRS
 from rasterio.features import bounds
 from rasterio.warp import transform_bounds
 from rio_tiler.constants import WGS84_CRS
+from urllib3.response import HTTPException
 
 from titiler.cmr.errors import InvalidDatetime
 
@@ -80,10 +81,20 @@ def parse_datetime(
     return datetime_, start, end
 
 
+def get_concept_id_umm(concept_id: str) -> Dict[str, Any]:
+    """Query CMR for the metadata for a concept_id"""
+    results = earthaccess.collection_query().concept_id(concept_id).get(1)
+
+    if not results:
+        raise HTTPException(400, f"concept_id {concept_id} not found")
+
+    return results[0]
+
+
 def get_resolution_degrees(concept_id: str) -> Tuple[Optional[float], Optional[float]]:
     """Query CMR to get the resolution of a dataset using its concept_id. If the units are in meters
     convert to degrees using the rough conversion factor of 0.00001 degrees per meter"""
-    ds = earthaccess.collection_query().concept_id(concept_id).get()[0]
+    ds = get_concept_id_umm(concept_id)
 
     try:
         resolution_info = ds["umm"]["SpatialExtent"]["HorizontalSpatialDomain"][


### PR DESCRIPTION
These new endpoints combine some collection-level metadata and a guess-and-check test on the first granule that comes back in a basic search to determine which backend (rasterio or xarray) is appropriate for the concept id, as well as other helpful information for setting the query parameters (e.g. `sel`).

Here is the example output for a netcdf dataset:

```bash
curl "http://localhost:8000/compatibility?concept_id=C2837626477-GES_DISC" | jq
```

```json
{
  "concept_id": "C2837626477-GES_DISC",
  "backend": "xarray",
  "datetime": [
    {
      "RangeDateTimes": [
        {
          "BeginningDateTime": "2005-01-01T00:00:00.000Z",
          "EndingDateTime": "2021-12-31T23:59:59.999Z"
        }
      ],
      "EndsAtPresentFlag": true
    }
  ],
  "variables": {
    "o3": {
      "shape": [
        12,
        27,
        160,
        320
      ],
      "dtype": "float32"
    }
  },
  "dimensions": {
    "time": 12,
    "nv": 2,
    "lon": 320,
    "lat": 160,
    "lev": 27
  },
  "coordinates": {
    "time": {
      "size": 12,
      "dtype": "datetime64[ns]"
    },
    "time_bnds": {
      "size": 24,
      "dtype": "datetime64[ns]"
    },
    "lon": {
      "size": 320,
      "dtype": "float32",
      "min": 0.0,
      "max": 358.875
    },
    "lon_bnds": {
      "size": 640,
      "dtype": "float32",
      "min": 0.5625,
      "max": 359.4375
    },
    "lat": {
      "size": 160,
      "dtype": "float32",
      "min": -89.14199829101562,
      "max": 89.14199829101562
    },
    "lat_bnds": {
      "size": 320,
      "dtype": "float32",
      "min": -89.69850158691406,
      "max": 89.69850158691406
    },
    "lev": {
      "size": 27,
      "dtype": "float32",
      "min": 60.0,
      "max": 1000.0
    }
  },
  "example_assets": "https://data.gesdisc.earthdata.nasa.gov/data/TCR2_MON_VERTCONCS/TRPSCRO3M3D.1/TROPESS_reanalysis_mon_o3_2005.nc"
}
```

If the dataset is raster-type (e.g. HLS) the information is not quite as rich, but should help users get un-stuck by showing the asset names which can help determine `band_regex`.

```bash
curl "http://localhost:8000/compatibility?concept_id=C2021957657-LPCLOUD" | jq
```

```json
{
  "concept_id": "C2021957657-LPCLOUD",
  "backend": "rasterio",
  "datetime": [
    {
      "RangeDateTimes": [
        {
          "BeginningDateTime": "2013-04-11T00:00:00.000Z"
        }
      ],
      "EndsAtPresentFlag": true,
      "PrecisionOfSeconds": 0,
      "TemporalResolution": {
        "Value": 1,
        "Unit": "Day"
      }
    }
  ],
  "example_assets": {
    "HLS.L30.T59WPT.2013101T001445.v2.0.B09.tif": "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.B09.tif",
    "HLS.L30.T59WPT.2013101T001445.v2.0.Fmask.tif": "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.Fmask.tif",
    "HLS.L30.T59WPT.2013101T001445.v2.0.B06.tif": "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.B06.tif",
    "HLS.L30.T59WPT.2013101T001445.v2.0.B01.tif": "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.B01.tif",
    "HLS.L30.T59WPT.2013101T001445.v2.0.B07.tif": "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.B07.tif",
    "HLS.L30.T59WPT.2013101T001445.v2.0.VZA.tif": "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.VZA.tif",
    "HLS.L30.T59WPT.2013101T001445.v2.0.B10.tif": "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.B10.tif",
    "HLS.L30.T59WPT.2013101T001445.v2.0.B04.tif": "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.B04.tif",
    "HLS.L30.T59WPT.2013101T001445.v2.0.SAA.tif": "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.SAA.tif",
    "HLS.L30.T59WPT.2013101T001445.v2.0.VAA.tif": "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.VAA.tif",
    "HLS.L30.T59WPT.2013101T001445.v2.0.B05.tif": "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.B05.tif",
    "HLS.L30.T59WPT.2013101T001445.v2.0.SZA.tif": "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.SZA.tif",
    "HLS.L30.T59WPT.2013101T001445.v2.0.B02.tif": "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.B02.tif",
    "HLS.L30.T59WPT.2013101T001445.v2.0.B03.tif": "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.B03.tif",
    "HLS.L30.T59WPT.2013101T001445.v2.0.B11.tif": "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.B11.tif"
  },
  "sample_asset_raster_info": {
    "bounds": [
      600000.0,
      7690200.0,
      709800.0,
      7800000.0
    ],
    "crs": "PROJCS[\"UTM Zone 59, Northern Hemisphere\",GEOGCS[\"Unknown datum based upon the WGS 84 ellipsoid\",DATUM[\"Not specified (based on WGS 84 spheroid)\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",171],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
    "band_metadata": [
      [
        "b1",
        {}
      ]
    ],
    "band_descriptions": [
      [
        "b1",
        "Cirrus"
      ]
    ],
    "dtype": "int16",
    "nodata_type": "Nodata",
    "colorinterp": [
      "gray"
    ],
    "scales": [
      0.0001
    ],
    "offsets": [
      0.0
    ],
    "driver": "GTiff",
    "count": 1,
    "width": 3660,
    "height": 3660,
    "overviews": [
      2,
      4,
      8,
      16
    ],
    "nodata_value": -9999.0
  }
}
```

I also added the `/concept_metadata` which just returns the collection/concept metadata direct from CMR.