### PR TITLE
[fix] prefetch s3 credentials

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,9 @@ from fastapi.testclient import TestClient
 from geojson_pydantic import Feature, FeatureCollection, Polygon
 from vcr.request import Request
 
+import numpy as np
+from rio_tiler.models import ImageData
+
 from titiler.cmr.backend import CMRBackend
 from titiler.cmr.settings import AuthSettings
 
@@ -192,3 +195,13 @@ def rasterio_query_params() -> Dict[str, str]:
         "bands_regex": "Fmask",
         "bands": "Fmask",
     }
+
+
+@pytest.fixture
+def image_data():
+    """
+    Create a proper ImageData object to return from tile
+    """
+    return ImageData(
+        np.zeros((3, 256, 256), dtype=np.uint8)  # RGB image
+    )

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,6 +1,10 @@
 """Test backend functions"""
 
+from unittest.mock import MagicMock, patch
+
+import numpy as np
 import pytest
+from rio_tiler.models import ImageData
 
 from titiler.cmr.backend import Access, CMRBackend
 
@@ -28,3 +32,77 @@ def test_get_assets(access: Access, expectation: str) -> None:
     assert asset_url
     assert isinstance(asset_url, dict)
     assert asset_url[band].startswith(expectation)
+
+
+def test_s3_credentials_used_for_session_creation() -> None:
+    """Test that s3_credentials from _get_s3_credentials are used to create AWS session."""
+    from rio_tiler.io import Reader
+
+    # Mock s3 credentials that would be returned by _get_s3_credentials
+    mock_s3_credentials = {
+        "accessKeyId": "test_access_key",
+        "secretAccessKey": "test_secret_key",
+        "sessionToken": "test_session_token",
+    }
+
+    # Mock asset that would be returned by assets_for_tile
+    mock_asset = {
+        "url": "s3://test-bucket/test-file.tif",
+        "provider": "TEST_PROVIDER",
+    }
+
+    # Create a proper ImageData object to return from tile
+    mock_image_data = ImageData(
+        np.zeros((3, 256, 256), dtype=np.uint8)  # RGB image
+    )
+
+    # Create a mock class that will pass isinstance checks
+    class MockReader:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            mock_instance = MagicMock()
+            mock_instance.tile.return_value = mock_image_data
+            return mock_instance
+
+        def __eq__(other):
+            # Make MockReader == Reader return True
+            if other is Reader:
+                return True
+            return super().__eq__(other)
+
+        def __exit__(self, *args):
+            pass
+
+    with CMRBackend(reader=MockReader) as backend:
+        # Mock assets_for_tile to return our test asset
+        with (
+            patch.object(backend, "assets_for_tile", return_value=[mock_asset]),
+            patch.object(
+                backend, "_get_s3_credentials", return_value=mock_s3_credentials
+            ) as mock_get_creds,
+            patch.object(backend, "_create_aws_session") as mock_create_session,
+            patch("rasterio.Env"),
+        ):
+            # Mock the session to return a valid context manager
+            mock_session = MagicMock()
+            mock_create_session.return_value = mock_session
+
+            # Call tile, which should trigger the credential flow
+            backend.tile(
+                0,
+                0,
+                0,
+                cmr_query={
+                    "concept_id": "C2021957657-LPCLOUD",
+                    "temporal": ("2024-02-11", "2024-02-13"),
+                },
+            )
+
+        # Verify that _get_s3_credentials was called with the asset
+        mock_get_creds.assert_called_once_with(mock_asset)
+
+        # Verify that _create_aws_session was called with the credentials
+        # returned by _get_s3_credentials
+        mock_create_session.assert_called_once_with(mock_s3_credentials)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -2,9 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
-import numpy as np
 import pytest
-from rio_tiler.models import ImageData
 
 from titiler.cmr.backend import Access, CMRBackend
 
@@ -34,7 +32,40 @@ def test_get_assets(access: Access, expectation: str) -> None:
     assert asset_url[band].startswith(expectation)
 
 
-def test_s3_credentials_used_for_session_creation() -> None:
+cmr_query = {
+    "concept_id": "C2021957657-LPCLOUD",
+    "temporal": ("2024-02-11", "2024-02-13"),
+}
+
+
+@pytest.mark.parametrize(
+    "method_name,method_call",
+    [
+        (
+            "tile",
+            lambda backend: backend.tile(
+                tile_x=0, tile_y=0, tile_z=0, cmr_query=cmr_query, bands_regex=""
+            ),
+        ),
+        (
+            "part",
+            lambda backend: backend.part(
+                bbox=(0, 0, 1, 1), cmr_query=cmr_query, bands_regex=""
+            ),
+        ),
+        (
+            "feature",
+            lambda backend: backend.feature(
+                shape={"type": "Point", "coordinates": [0, 0]},
+                cmr_query=cmr_query,
+                bands_regex="",
+            ),
+        ),
+    ],
+)
+def test_s3_credentials_used_for_session_creation(
+    method_name, method_call, image_data
+) -> None:
     """Test that s3_credentials from _get_s3_credentials are used to create AWS session."""
     from rio_tiler.io import Reader
 
@@ -51,11 +82,6 @@ def test_s3_credentials_used_for_session_creation() -> None:
         "provider": "TEST_PROVIDER",
     }
 
-    # Create a proper ImageData object to return from tile
-    mock_image_data = ImageData(
-        np.zeros((3, 256, 256), dtype=np.uint8)  # RGB image
-    )
-
     # Create a mock class that will pass isinstance checks
     class MockReader:
         def __init__(self, *args, **kwargs):
@@ -63,22 +89,25 @@ def test_s3_credentials_used_for_session_creation() -> None:
 
         def __enter__(self):
             mock_instance = MagicMock()
-            mock_instance.tile.return_value = mock_image_data
+            # Set the method to return the image_data
+            getattr(mock_instance, method_name).return_value = image_data
             return mock_instance
-
-        def __eq__(other):
-            # Make MockReader == Reader return True
-            if other is Reader:
-                return True
-            return super().__eq__(other)
 
         def __exit__(self, *args):
             pass
 
+    def class_eq(self, other):
+        if other is MockReader:
+            return True
+        return type.__eq__(self, other)
+
     with CMRBackend(reader=MockReader) as backend:
-        # Mock assets_for_tile to return our test asset
+        # Mock asset methods to return our test asset
         with (
             patch.object(backend, "assets_for_tile", return_value=[mock_asset]),
+            patch.object(backend, "assets_for_bbox", return_value=[mock_asset]),
+            patch.object(backend, "get_assets", return_value=[mock_asset]),
+            patch.object(type(Reader), "__eq__", class_eq),
             patch.object(
                 backend, "_get_s3_credentials", return_value=mock_s3_credentials
             ) as mock_get_creds,
@@ -90,15 +119,7 @@ def test_s3_credentials_used_for_session_creation() -> None:
             mock_create_session.return_value = mock_session
 
             # Call tile, which should trigger the credential flow
-            backend.tile(
-                0,
-                0,
-                0,
-                cmr_query={
-                    "concept_id": "C2021957657-LPCLOUD",
-                    "temporal": ("2024-02-11", "2024-02-13"),
-                },
-            )
+            method_call(backend)
 
         # Verify that _get_s3_credentials was called with the asset
         mock_get_creds.assert_called_once_with(mock_asset)

--- a/titiler/cmr/backend.py
+++ b/titiler/cmr/backend.py
@@ -290,10 +290,11 @@ class CMRBackend(BaseBackend):
                 f"No assets found for tile {tile_z}-{tile_x}-{tile_y}"
             )
 
-        def _reader(asset: Asset, x: int, y: int, z: int, **kwargs: Any) -> ImageData:
-            s3_credentials = self._get_s3_credentials(asset)
+        asset = mosaic_assets[0]
+        s3_credentials = self._get_s3_credentials(asset)
 
-            if isinstance(self.reader, type) and self.reader == Reader:
+        def _reader(asset: Asset, x: int, y: int, z: int, **kwargs: Any) -> ImageData:
+            if isinstance(self.reader, type) and self.reader.__eq__(Reader):
                 aws_session = self._create_aws_session(s3_credentials)
 
                 with rasterio.Env(aws_session):

--- a/titiler/cmr/backend.py
+++ b/titiler/cmr/backend.py
@@ -294,7 +294,7 @@ class CMRBackend(BaseBackend):
         s3_credentials = self._get_s3_credentials(asset)
 
         def _reader(asset: Asset, x: int, y: int, z: int, **kwargs: Any) -> ImageData:
-            if isinstance(self.reader, type) and self.reader.__eq__(Reader):
+            if isinstance(self.reader, type) and self.reader == Reader:
                 aws_session = self._create_aws_session(s3_credentials)
 
                 with rasterio.Env(aws_session):
@@ -355,9 +355,10 @@ class CMRBackend(BaseBackend):
         if not mosaic_assets:
             raise NoAssetFoundError("No assets found for bbox input")
 
-        def _reader(asset: Asset, bbox: BBox, **kwargs: Any) -> ImageData:
-            s3_credentials = self._get_s3_credentials(asset)
+        asset = mosaic_assets[0]
+        s3_credentials = self._get_s3_credentials(asset)
 
+        def _reader(asset: Asset, bbox: BBox, **kwargs: Any) -> ImageData:
             if isinstance(self.reader, type) and self.reader == Reader:
                 aws_session = self._create_aws_session(s3_credentials)
 
@@ -415,9 +416,10 @@ class CMRBackend(BaseBackend):
         if not mosaic_assets:
             raise NoAssetFoundError("No assets found for Geometry")
 
-        def _reader(asset: Asset, shape: Dict, **kwargs: Any) -> ImageData:
-            s3_credentials = self._get_s3_credentials(asset)
+        asset = mosaic_assets[0]
+        s3_credentials = self._get_s3_credentials(asset)
 
+        def _reader(asset: Asset, shape: Dict, **kwargs: Any) -> ImageData:
             if isinstance(self.reader, type) and self.reader == Reader:
                 aws_session = self._create_aws_session(s3_credentials)
 


### PR DESCRIPTION
Prefetch S3 credentials to resolve errors emanating from earthaccess.Auth.get_s3_credentials in multithreaded contexts. 

Resolves #92 

Putting in draft state in case we decide to go with the simpler, but probably slower, credential lock option. In other words, continue to fetch S3 credentials in threads but using a credential lock.

This option seems preferable if we are not concerned about combining assets from multiple providers.