### PR TITLE
[fix] add sessions reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - interpolate {datetime} in if sel includes {dim}={datetime} ([#78](https://github.com/developmentseed/titiler-cmr/pull/78))
 - /compatibility and /concept_metadata endpoints ([#80](https://github.com/developmentseed/titiler-cmr/pull/80))
+- implemented a new reader class `AWSSessionsReader` and use it with `MultiFilesBandsReader` in `CMRBackend` to address sessions not being passed to child threads in a multi-threaded context when using `rasterio.Env(session=)` ([#95](https://github.com/developmentseed/titiler-cmr/pull/95)). Adresses #91.
 
 ## [v0.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - interpolate {datetime} in if sel includes {dim}={datetime} ([#78](https://github.com/developmentseed/titiler-cmr/pull/78))
 - /compatibility and /concept_metadata endpoints ([#80](https://github.com/developmentseed/titiler-cmr/pull/80))
-- implemented a new reader class `AWSSessionsReader` and use it with `MultiFilesBandsReader` in `CMRBackend` to address sessions not being passed to child threads in a multi-threaded context when using `rasterio.Env(session=)` ([#95](https://github.com/developmentseed/titiler-cmr/pull/95)). Adresses #91.
+- implemented a new reader class `AWSSessionsReader` and use it with `MultiFilesBandsReader` in `CMRBackend` to address sessions not being passed to child threads in a multi-threaded context when using `rasterio.Env(session=)` ([#95](https://github.com/developmentseed/titiler-cmr/pull/95)). Adresses [#91](https://github.com/developmentseed/titiler-cmr/issues/91).
 
 ## [v0.2.0]
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -35,14 +35,14 @@ class TestAWSSessionsReader:
         # Create reader
         reader = AWSSessionsReader(test_file, s3_credentials=s3_credentials)
 
-        # Before entering context, session should be None
+        # reader.aws_session should be set on init, but not env_ctx
         assert isinstance(reader.aws_session, AWSSession)
         assert reader.env_ctx is None
 
         # Enter context
         reader.__enter__()
 
-        # After entering, Env context should be created
+        # After entering, env context should be created
         assert isinstance(reader.env_ctx, RasterioEnv)
 
         # Clean up
@@ -69,8 +69,9 @@ class TestMultiFilesBandsReader:
         }
 
         # Create input dictionary mapping band names to URLs
+        band_url = "s3://test-bucket/red.tif"
         input_files = {
-            "red": "s3://test-bucket/red.tif",
+            "red": band_url,
         }
 
         # Create reader options that include s3_credentials
@@ -88,15 +89,11 @@ class TestMultiFilesBandsReader:
         assert multi_reader.reader == AWSSessionsReader
         assert multi_reader.reader_options == reader_options
 
-        # Now test that when we create a reader instance (as MultiBandReader.tile does),
-        # the AWSSessionsReader gets the s3_credentials
-        url = multi_reader._get_band_url("red")
-
         # Mock the parent __attrs_post_init__ to avoid opening files
         with patch("rio_tiler.io.rasterio.Reader.__attrs_post_init__"):
             # Create a reader instance the same way MultiBandReader.tile does
             reader_instance = multi_reader.reader(
-                url, tms=multi_reader.tms, **multi_reader.reader_options
+                band_url, tms=multi_reader.tms, **multi_reader.reader_options
             )
 
             # Verify the reader instance has the s3_credentials

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,0 +1,104 @@
+"""Test titiler.cmr.reader module."""
+
+from unittest.mock import patch
+
+
+from titiler.cmr.reader import AWSSessionsReader, MultiFilesBandsReader
+
+
+class TestAWSSessionsReader:
+    """Test AWSSessionsReader class."""
+
+    @patch("rio_tiler.io.rasterio.Reader.__attrs_post_init__")
+    def test_aws_session_reader_context_manager(self, mock_post_init):
+        """Test AWSSessionsReader context manager properly sets up AWS session.
+
+        This test verifies that AWSSessionsReader:
+        1. Creates a real AWSSession with the provided credentials
+        2. Creates a rasterio.Env context with that session
+        3. Properly enters and exits those contexts
+        """
+        from rasterio.session import AWSSession
+        from rasterio import Env as RasterioEnv
+
+        # Skip the parent __attrs_post_init__ to avoid opening files
+        mock_post_init.return_value = None
+
+        s3_credentials = {
+            "accessKeyId": "test_key",
+            "secretAccessKey": "test_secret",
+            "sessionToken": "test_token",
+        }
+
+        test_file = "s3://test-bucket/test-file.tif"
+
+        # Create reader
+        reader = AWSSessionsReader(test_file, s3_credentials=s3_credentials)
+
+        # Before entering context, session should be None
+        assert isinstance(reader.aws_session, AWSSession)
+        assert reader.env_ctx is None
+
+        # Enter context
+        reader.__enter__()
+
+        # After entering, Env context should be created
+        assert isinstance(reader.env_ctx, RasterioEnv)
+
+        # Clean up
+        reader.__exit__(None, None, None)
+
+
+class TestMultiFilesBandsReader:
+    """Test MultiFilesBandsReader class."""
+
+    def test_multifiles_bands_reader_with_aws_session_reader(self):
+        """Test that MultiFilesBandsReader passes s3_credentials to AWSSessionsReader instances.
+
+        When MultiFilesBandsReader is initialized with reader=AWSSessionsReader and
+        s3_credentials in reader_options, those credentials should be passed to each
+        AWSSessionsReader instance created for reading individual bands.
+        """
+        from rasterio.session import AWSSession
+
+        # Mock S3 credentials
+        s3_credentials = {
+            "accessKeyId": "test_key",
+            "secretAccessKey": "test_secret",
+            "sessionToken": "test_token",
+        }
+
+        # Create input dictionary mapping band names to URLs
+        input_files = {
+            "red": "s3://test-bucket/red.tif",
+        }
+
+        # Create reader options that include s3_credentials
+        reader_options = {"s3_credentials": s3_credentials}
+
+        # Initialize MultiFilesBandsReader with explicit AWSSessionsReader
+        multi_reader = MultiFilesBandsReader(
+            input=input_files,
+            reader=AWSSessionsReader,
+            reader_options=reader_options,
+        )
+
+        # Verify initialization
+        assert multi_reader.input == input_files
+        assert multi_reader.reader == AWSSessionsReader
+        assert multi_reader.reader_options == reader_options
+
+        # Now test that when we create a reader instance (as MultiBandReader.tile does),
+        # the AWSSessionsReader gets the s3_credentials
+        url = multi_reader._get_band_url("red")
+
+        # Mock the parent __attrs_post_init__ to avoid opening files
+        with patch("rio_tiler.io.rasterio.Reader.__attrs_post_init__"):
+            # Create a reader instance the same way MultiBandReader.tile does
+            reader_instance = multi_reader.reader(
+                url, tms=multi_reader.tms, **multi_reader.reader_options
+            )
+
+            # Verify the reader instance has the s3_credentials
+            assert isinstance(reader_instance, AWSSessionsReader)
+            assert isinstance(reader_instance.aws_session, AWSSession)

--- a/titiler/cmr/backend.py
+++ b/titiler/cmr/backend.py
@@ -28,6 +28,7 @@ from rio_tiler.types import BBox
 from titiler.cmr.logger import logger
 from titiler.cmr.settings import AuthSettings, CacheSettings, RetrySettings
 from titiler.cmr.utils import retry
+from titiler.cmr.reader import AWSSessionsReader, MultiFilesBandsReader
 
 Access = Literal["direct", "external"]
 
@@ -125,9 +126,18 @@ class CMRBackend(BaseBackend):
 
     def _build_reader_options(self, s3_credentials: Optional[Dict]) -> Dict:
         """Build reader options with opener_options if s3_credentials provided."""
+        options = {**self.reader_options}
+        if self.reader == Reader or self.reader == MultiFilesBandsReader:
+            if s3_credentials:
+                options["reader_options"] = options.get("reader_options", {})
+                options["reader_options"]["s3_credentials"] = s3_credentials
+                options["reader"] = AWSSessionsReader
+            return options
+
+        # For xarray-based openers
         if s3_credentials:
             return {
-                **self.reader_options,
+                **options,
                 "opener_options": {
                     "s3_credentials": {
                         "key": s3_credentials["accessKeyId"],
@@ -137,7 +147,7 @@ class CMRBackend(BaseBackend):
                 },
             }
         else:
-            return self.reader_options
+            return options
 
     def _create_aws_session(
         self, s3_credentials: Optional[Dict]
@@ -292,18 +302,6 @@ class CMRBackend(BaseBackend):
 
         def _reader(asset: Asset, x: int, y: int, z: int, **kwargs: Any) -> ImageData:
             s3_credentials = self._get_s3_credentials(asset)
-
-            if isinstance(self.reader, type) and self.reader == Reader:
-                aws_session = self._create_aws_session(s3_credentials)
-
-                with rasterio.Env(aws_session):
-                    with self.reader(
-                        asset["url"],
-                        tms=self.tms,
-                        **self.reader_options,
-                    ) as src_dst:
-                        return src_dst.tile(x, y, z, **kwargs)
-
             options = self._build_reader_options(s3_credentials)
 
             with self.reader(
@@ -356,17 +354,6 @@ class CMRBackend(BaseBackend):
 
         def _reader(asset: Asset, bbox: BBox, **kwargs: Any) -> ImageData:
             s3_credentials = self._get_s3_credentials(asset)
-
-            if isinstance(self.reader, type) and self.reader == Reader:
-                aws_session = self._create_aws_session(s3_credentials)
-
-                with rasterio.Env(aws_session):
-                    with self.reader(
-                        asset["url"],
-                        **self.reader_options,
-                    ) as src_dst:
-                        return src_dst.part(bbox, **kwargs)
-
             options = self._build_reader_options(s3_credentials)
 
             with self.reader(
@@ -416,17 +403,6 @@ class CMRBackend(BaseBackend):
 
         def _reader(asset: Asset, shape: Dict, **kwargs: Any) -> ImageData:
             s3_credentials = self._get_s3_credentials(asset)
-
-            if isinstance(self.reader, type) and self.reader == Reader:
-                aws_session = self._create_aws_session(s3_credentials)
-
-                with rasterio.Env(aws_session):
-                    with self.reader(
-                        asset["url"],
-                        **self.reader_options,
-                    ) as src_dst:
-                        return src_dst.feature(shape, **kwargs)
-
             options = self._build_reader_options(s3_credentials)
 
             with self.reader(

--- a/titiler/cmr/backend.py
+++ b/titiler/cmr/backend.py
@@ -126,6 +126,7 @@ class CMRBackend(BaseBackend):
 
     def _build_reader_options(self, s3_credentials: Optional[Dict]) -> Dict:
         """Build reader options with opener_options if s3_credentials provided."""
+        # Create a shallow copy of `reader_options` to avoid mutating self.reader_options directly.
         options = {**self.reader_options}
         if self.reader == Reader or self.reader == MultiFilesBandsReader:
             if s3_credentials:

--- a/titiler/cmr/backend.py
+++ b/titiler/cmr/backend.py
@@ -7,8 +7,6 @@ from typing import Any, Dict, List, Literal, Optional, Tuple, Type, TypedDict, U
 
 import attr
 import earthaccess
-import rasterio
-import rasterio.session
 from cachetools import TTLCache, cached
 from cachetools.keys import hashkey
 from cogeo_mosaic.backends import BaseBackend
@@ -149,18 +147,6 @@ class CMRBackend(BaseBackend):
             }
         else:
             return options
-
-    def _create_aws_session(
-        self, s3_credentials: Optional[Dict]
-    ) -> Optional[rasterio.session.AWSSession]:
-        """Create rasterio AWSSession from s3 credentials."""
-        if s3_credentials:
-            return rasterio.session.AWSSession(
-                aws_access_key_id=s3_credentials["accessKeyId"],
-                aws_secret_access_key=s3_credentials["secretAccessKey"],
-                aws_session_token=s3_credentials["sessionToken"],
-            )
-        return None
 
     def assets_for_tile(
         self, x: int, y: int, z: int, access: Access = "direct", **kwargs: Any

--- a/titiler/cmr/reader.py
+++ b/titiler/cmr/reader.py
@@ -19,6 +19,9 @@ from rio_tiler.constants import WEB_MERCATOR_TMS, WGS84_CRS
 from rio_tiler.errors import InvalidBandName
 from rio_tiler.io import BaseReader, MultiBandReader, Reader
 
+import rasterio
+from rasterio.session import AWSSession
+
 from titiler.cmr.settings import CacheSettings
 
 # Use simple in-memory cache for now (we can switch to redis later)
@@ -124,6 +127,46 @@ def xarray_open_dataset(
     cache_client[cache_key] = pickle.dumps(ds)
 
     return ds
+
+
+class AWSSessionsReader(Reader):
+    """Reader that adds AWS session context to tile operations."""
+
+    s3_credentials: Dict[str, str] = attr.ib()
+
+    def __init__(self, *args, s3_credentials: dict, **kwargs):
+        """
+        Args:
+            s3_credentials: Dict with accessKeyId, secretAccessKey, sessionToken
+            *args, **kwargs: Passed to parent Reader class
+        """
+        self.aws_session = AWSSession(
+            aws_access_key_id=s3_credentials["accessKeyId"],
+            aws_secret_access_key=s3_credentials["secretAccessKey"],
+            aws_session_token=s3_credentials["sessionToken"],
+        )
+        with rasterio.Env(session=self.aws_session):
+            super().__init__(*args, **kwargs)
+        self.env_ctx = None
+
+    def __enter__(self):
+        """
+        Create and enter AWS session context
+        """
+        self.env_ctx = rasterio.Env(session=self.aws_session)
+        self.env_ctx.__enter__()
+
+        # Call parent's __enter__
+        return super().__enter__()
+
+    def __exit__(self, *args):
+        """
+        Exit context in reverse order
+        """
+        result = super().__exit__(*args)
+        if self.env_ctx:
+            self.env_ctx.__exit__(*args)
+        return result
 
 
 @attr.s

--- a/titiler/cmr/reader.py
+++ b/titiler/cmr/reader.py
@@ -151,12 +151,14 @@ class AWSSessionsReader(Reader):
 
     def __enter__(self):
         """
-        Create and enter AWS session context
+        Setup the environment context manager with the instance's AWSSession
         """
+
+        # Enter the Rasterio environment with AWS credentials
         self.env_ctx = rasterio.Env(session=self.aws_session)
         self.env_ctx.__enter__()
 
-        # Call parent's __enter__
+        # Call parent's __enter__ to perform its initialization
         return super().__enter__()
 
     def __exit__(self, *args):


### PR DESCRIPTION
This PR address #91 by implementing a new reader class `AWSSessionsReader` and using it with `MultiFilesBandsReader`. The `AWSSessionsReader` wraps the `super().__init__` call in an AWSSession, as the Rasterio Reader `__init__` function itself opens the dataset and sets up the environment context manger with the AWSSession.

