### PR TITLE
feat: support custom bootstrap qualifier

### DIFF
--- a/infrastructure/aws/cdk/app.py
+++ b/infrastructure/aws/cdk/app.py
@@ -147,6 +147,10 @@ class LambdaStack(Stack):
 
 
 app = App()
+if stack_settings.bootstrap_qualifier:
+    app.node.set_context(
+        "@aws-cdk/core:bootstrapQualifier", stack_settings.bootstrap_qualifier
+    )
 
 perms = []
 if app_settings.buckets:

--- a/infrastructure/aws/cdk/config.py
+++ b/infrastructure/aws/cdk/config.py
@@ -2,6 +2,7 @@
 
 from typing import List, Optional
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -12,6 +13,11 @@ class StackSettings(BaseSettings):
     stage: str = "production"
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    bootstrap_qualifier: Optional[str] = Field(
+        None,
+        description="Custom bootstrap qualifier override if not using a default installation of AWS CDK Toolkit to synthesize app.",
+    )
 
 
 class AppSettings(BaseSettings):


### PR DESCRIPTION
In high-security environments, the default bootstrap qualifier may not be supported. This change allows us to provide a custom qualifier in order to deploy to that environment.