### PR TITLE
feat: add permission boundary support

### DIFF
--- a/infrastructure/aws/cdk/app.py
+++ b/infrastructure/aws/cdk/app.py
@@ -3,7 +3,7 @@
 import os
 from typing import Any, List, Optional
 
-from aws_cdk import App, CfnOutput, Duration, Stack, Tags, aws_lambda
+from aws_cdk import App, CfnOutput, Duration, Stack, Tags, aws_lambda, Aspects
 from aws_cdk import aws_apigatewayv2 as apigw
 from aws_cdk import aws_cloudwatch as cloudwatch
 from aws_cdk import aws_cloudwatch_actions as cloudwatch_actions
@@ -15,6 +15,7 @@ from aws_cdk.aws_apigatewayv2_integrations import HttpLambdaIntegration
 from aws_cdk.aws_ecr_assets import Platform
 from config import AppSettings, StackSettings
 from constructs import Construct
+from permissions_boundary.construct import PermissionsBoundaryAspect
 
 stack_settings, app_settings = StackSettings(), AppSettings()
 
@@ -42,7 +43,6 @@ class LambdaStack(Stack):
         id: str,
         memory: int = 1024,
         timeout: int = 30,
-        runtime: aws_lambda.Runtime = aws_lambda.Runtime.PYTHON_3_12,
         concurrent: Optional[int] = None,
         permissions: Optional[List[iam.PolicyStatement]] = None,
         role_arn: Optional[str] = None,
@@ -51,6 +51,15 @@ class LambdaStack(Stack):
     ) -> None:
         """Define stack."""
         super().__init__(scope, id, *kwargs)
+
+        if stack_settings.permissions_boundary_policy_name:
+            permissions_boundary_policy = iam.ManagedPolicy.from_managed_policy_name(
+                self,
+                "permissions-boundary",
+                stack_settings.permissions_boundary_policy_name,
+            )
+            iam.PermissionsBoundary.of(self).apply(permissions_boundary_policy)
+            Aspects.of(self).add(PermissionsBoundaryAspect(permissions_boundary_policy))
 
         permissions = permissions or []
 

--- a/infrastructure/aws/cdk/config.py
+++ b/infrastructure/aws/cdk/config.py
@@ -19,6 +19,11 @@ class StackSettings(BaseSettings):
         description="Custom bootstrap qualifier override if not using a default installation of AWS CDK Toolkit to synthesize app.",
     )
 
+    permissions_boundary_policy_name: Optional[str] = Field(
+        None,
+        description="Name of IAM policy to define stack permissions boundary",
+    )
+
 
 class AppSettings(BaseSettings):
     """Application settings"""

--- a/infrastructure/aws/cdk/permissions_boundary/construct.py
+++ b/infrastructure/aws/cdk/permissions_boundary/construct.py
@@ -1,0 +1,57 @@
+"""Class that applies permissions boundary to all the roles created within a Stack"""
+
+from typing import Union
+
+import jsii
+from aws_cdk import IAspect, aws_iam
+from constructs import IConstruct
+from jsii._reference_map import _refs
+from jsii._utils import Singleton
+
+
+@jsii.implements(IAspect)
+class PermissionsBoundaryAspect:
+    """
+    This aspect finds all aws_iam.Role objects in a node (ie. CDK stack) and sets permissions boundary to the given ARN.
+    """
+
+    def __init__(self, permissions_boundary: Union[aws_iam.ManagedPolicy, str]) -> None:
+        """
+        :param permissions_boundary: Either aws_iam.ManagedPolicy object or managed policy's ARN string
+        """
+        self.permissions_boundary = permissions_boundary
+
+    def visit(self, construct_ref: IConstruct) -> None:
+        """
+        construct_ref only contains a string reference to an object. To get the actual object, we need to resolve it using JSII mapping.
+        :param construct_ref: ObjRef object with string reference to the actual object.
+        :return: None
+        """
+        if isinstance(construct_ref, jsii._kernel.ObjRef) and hasattr(
+            construct_ref, "ref"
+        ):
+            kernel = Singleton._instances[
+                jsii._kernel.Kernel
+            ]  # The same object is available as: jsii.kernel
+            resolve = _refs.resolve(kernel, construct_ref)
+        else:
+            resolve = construct_ref
+
+        def _walk(obj):
+            if isinstance(obj, aws_iam.Role):
+                cfn_role = obj.node.find_child("Resource")
+                policy_arn = (
+                    self.permissions_boundary
+                    if isinstance(self.permissions_boundary, str)
+                    else self.permissions_boundary.managed_policy_arn
+                )
+                cfn_role.add_property_override("PermissionsBoundary", policy_arn)
+            else:
+                if hasattr(obj, "permissions_node"):
+                    for c in obj.permissions_node.children:
+                        _walk(c)
+                if hasattr(obj, "node") and obj.node.children:
+                    for c in obj.node.children:
+                        _walk(c)
+
+        _walk(resolve)


### PR DESCRIPTION
Following up from #99 - our high security environment requires stacks to apply a permission boundary to all nodes. I think this is causing [deployment issues](https://github.com/NASA-IMPACT/veda-deploy/actions/runs/19651951520/job/56285764802) where the `ServiceRole` and `LogRetention` roles associated with the lambda function are missing this boundary.