### PR TITLE
Error message should report `bidx` parameter missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the missing parameter error message "`indexes` must be provided if not providing `bands_regex` and `bands`". The [alias](https://fastapi.tiangolo.com/tutorial/query-params-str-validations/#alias-parameters) for the `indexes` parameter is `bidx`, so the `bidx` parameter is what is missing from the parameter string. ([#101](https://github.com/developmentseed/titiler-cmr/pull/101))
+
 ## [v0.3.0]
 
 ### Added

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -47,7 +47,7 @@ class TestParseReaderOptions:
 
         with pytest.raises(
             AssertionError,
-            match="`indexes` must be provided if not providing `bands_regex` and `bands`",
+            match="`bidx` must be provided if not providing `bands_regex` and `bands`",
         ):
             parse_reader_options(
                 rasterio_params=rasterio_params,

--- a/titiler/cmr/factory.py
+++ b/titiler/cmr/factory.py
@@ -167,7 +167,7 @@ def parse_reader_options(
 
         else:
             assert rasterio_params.indexes, (
-                "`indexes` must be provided if not providing `bands_regex` and `bands`"
+                "`bidx` must be provided if not providing `bands_regex` and `bands`"
             )
 
             reader = rasterio.Reader


### PR DESCRIPTION
`bidx` is the alias for `indexes` (https://fastapi.tiangolo.com/tutorial/query-params-str-validations/#alias-parameters), so the error message should report that `bidx` is missing, not indexes.