### PR TITLE
Remove deprecated FastAPI on_event decorator.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,27 @@ cdk.context.json
 
 notebooks/
 .envrc
+
+# Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode
+
+### VisualStudioCode ###
+.vscode/*
+#!.vscode/settings.json
+#!.vscode/tasks.json
+#!.vscode/launch.json
+#!.vscode/extensions.json
+#!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/visualstudiocode

--- a/infrastructure/aws/lambda/handler.py
+++ b/infrastructure/aws/lambda/handler.py
@@ -4,14 +4,13 @@ import asyncio
 import logging
 import os
 import warnings
-from typing import Any, Dict
+from typing import Any
 
-import earthaccess
 from mangum import Mangum
+from mangum.types import LambdaContext, LambdaEvent
 
 from titiler.cmr.logger import configure_logging
 from titiler.cmr.main import app
-from titiler.cmr.settings import AuthSettings
 
 configure_logging()
 
@@ -19,22 +18,10 @@ warnings.filterwarnings("ignore", category=UserWarning)
 warnings.filterwarnings("ignore", category=FutureWarning)
 logging.getLogger("numexpr").setLevel(logging.WARNING)
 
-auth_config = AuthSettings()
-
-
-@app.on_event("startup")
-async def startup_event() -> None:
-    """startup."""
-    if auth_config.strategy == "environment":
-        app.state.cmr_auth = earthaccess.login(strategy="environment")
-    else:
-        app.state.cmr_auth = None
-
 
 handler = Mangum(
     app,
     lifespan="off",
-    api_gateway_base_path=None,
     text_mime_types=[
         "application/json",
         "application/javascript",
@@ -48,6 +35,6 @@ if "AWS_EXECUTION_ENV" in os.environ:
     loop.run_until_complete(app.router.startup())
 
 
-def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+def lambda_handler(event: LambdaEvent, context: LambdaContext) -> dict[str, Any]:
     """Lambda handler with container-specific optimizations and OTEL tracing."""
     return handler(event, context)


### PR DESCRIPTION
The `lifespan` function in `main.py` takes the place of the function removed in this commit, but it seems that when `lifespan` was added, the now-removed function was not removed, as it should have been.

(Also, tidied up some type annotations in the file where I removed the obsolete function.)