### PR TITLE
feat: add option to deploy with earthdata credentials

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -18,6 +18,7 @@ jobs:
   deploy:
     name: Deploy to dev 🚀
     runs-on: ubuntu-latest
+    environment: dev
     if: >
       github.event_name != 'pull_request' ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy-dev'))    
@@ -52,9 +53,10 @@ jobs:
           dir: "./infrastructure/aws"
           env_aws_secret_name: ""
         env:
-          # I'm not sure this is in use anymore, should we remove it?
+          EARTHDATA_USERNAME: ${{ vars.earthdata_username }}
+          EARTHDATA_PASSWORD: ${{ secrets.earthdata_password }}
+          STAGE: ${{ vars.stage }}
+          TITILER_CMR_AWS_REQUEST_PAYER: ${{ vars.titiler_cmr_aws_request_payer }}
           TITILER_CMR_ROLE_ARN: ${{ secrets.titiler_cmr_role_arn }}
           TITILER_CMR_ROOT_PATH: ''
-          STAGE: dev
-          TITILER_CMR_AWS_REQUEST_PAYER: requester
-          TITILER_CMR_S3_AUTH_STRATEGY: iam
+          TITILER_CMR_S3_AUTH_STRATEGY: ${{ vars.titiler_cmr_s3_auth_strategy }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add Earthdata Login based S3 access, except for the rasterio backend, to be
   addressed separately.
   ([#112](https://github.com/developmentseed/titiler-cmr/pull/112))
+- Update deployment application to add EARTHDATA_USERNAME and EARTHDATA_PASSWORD to Lambda environment ([#120](https://github.com/developmentseed/titiler-cmr/pull/120))
 
 ### Fixed
 

--- a/infrastructure/aws/cdk.json
+++ b/infrastructure/aws/cdk.json
@@ -1,3 +1,3 @@
 {
-    "app": "python3 cdk/app.py"
+  "app": "python3 -m cdk.app"
 }

--- a/infrastructure/aws/cdk/app.py
+++ b/infrastructure/aws/cdk/app.py
@@ -1,9 +1,9 @@
 """Construct App."""
 
 import os
-from typing import Any, List, Optional
+from typing import Any
 
-from aws_cdk import App, CfnOutput, Duration, Stack, Tags, aws_lambda, Aspects
+from aws_cdk import App, Aspects, CfnOutput, Duration, Stack, Tags, aws_lambda
 from aws_cdk import aws_apigatewayv2 as apigw
 from aws_cdk import aws_cloudwatch as cloudwatch
 from aws_cdk import aws_cloudwatch_actions as cloudwatch_actions
@@ -13,11 +13,15 @@ from aws_cdk import aws_sns as sns
 from aws_cdk import aws_sns_subscriptions as subscriptions
 from aws_cdk.aws_apigatewayv2_integrations import HttpLambdaIntegration
 from aws_cdk.aws_ecr_assets import Platform
-from config import AppSettings, StackSettings
 from constructs import Construct
-from permissions_boundary.construct import PermissionsBoundaryAspect
 
-stack_settings, app_settings = StackSettings(), AppSettings()
+from .config import AppSettings, StackSettings
+from .permissions_boundary.construct import PermissionsBoundaryAspect
+
+stack_settings, app_settings = (
+    StackSettings(),
+    AppSettings(),
+)
 
 DEFAULT_ENV = {
     "AWS_LAMBDA_LOG_FORMAT": "JSON",
@@ -41,11 +45,8 @@ class LambdaStack(Stack):
         self,
         scope: Construct,
         id: str,
-        memory: int = 1024,
-        timeout: int = 30,
-        concurrent: Optional[int] = None,
-        permissions: Optional[List[iam.PolicyStatement]] = None,
-        role_arn: Optional[str] = None,
+        app_settings: AppSettings,
+        stack_settings: StackSettings,
         context_dir: str = "../../",
         **kwargs: Any,
     ) -> None:
@@ -61,27 +62,39 @@ class LambdaStack(Stack):
             iam.PermissionsBoundary.of(self).apply(permissions_boundary_policy)
             Aspects.of(self).add(PermissionsBoundaryAspect(permissions_boundary_policy))
 
-        permissions = permissions or []
-
         iam_reader_role = None
-        if role_arn:
+        if app_settings.role_arn:
             iam_reader_role = iam.Role.from_role_arn(
                 self,
                 "veda-reader-dev-role",
-                role_arn=role_arn,
+                role_arn=app_settings.role_arn,
             )
 
         lambda_env = {
             **DEFAULT_ENV,
             "TITILER_CMR_ROOT_PATH": app_settings.root_path,
             "TITILER_CMR_S3_AUTH_STRATEGY": app_settings.s3_auth_strategy,
-            "TITILER_CMR_TELEMETRY_ENABLED": "TRUE",
-            "OTEL_PYTHON_DISABLED_INSTRUMENTATIONS": "aws-lambda,requests,urllib3,aiohttp-client",  # Disable aws-lambda auto-instrumentation (handled by otel_wrapper.py)
-            "OTEL_PROPAGATORS": "tracecontext,baggage,xray",
-            "OPENTELEMETRY_COLLECTOR_CONFIG_URI": "/opt/collector-config/config.yaml",
-            # AWS_LAMBDA_LOG_FORMAT not set - using custom JSON formatter in handler.py
-            "AWS_LAMBDA_EXEC_WRAPPER": "/opt/otel-instrument",  # Enable OTEL wrapper to avoid circular import
         }
+
+        if app_settings.telemetry_enabled:
+            lambda_env.update(
+                {
+                    "TITILER_CMR_TELEMETRY_ENABLED": "TRUE",
+                    "OTEL_PYTHON_DISABLED_INSTRUMENTATIONS": "aws-lambda,requests,urllib3,aiohttp-client",  # Disable aws-lambda auto-instrumentation (handled by otel_wrapper.py)
+                    "OTEL_PROPAGATORS": "tracecontext,baggage,xray",
+                    "OPENTELEMETRY_COLLECTOR_CONFIG_URI": "/opt/collector-config/config.yaml",
+                    # AWS_LAMBDA_LOG_FORMAT not set - using custom JSON formatter in handler.py
+                    "AWS_LAMBDA_EXEC_WRAPPER": "/opt/otel-instrument",  # Enable OTEL wrapper to avoid circular import
+                }
+            )
+
+        if app_settings.s3_auth_strategy == "environment":
+            lambda_env.update(
+                {
+                    "EARTHDATA_USERNAME": app_settings.earthdata_username,
+                    "EARTHDATA_PASSWORD": app_settings.earthdata_password,
+                }
+            )
 
         if app_settings.aws_request_payer:
             lambda_env["AWS_REQUEST_PAYER"] = app_settings.aws_request_payer
@@ -94,17 +107,25 @@ class LambdaStack(Stack):
                 file="infrastructure/aws/lambda/Dockerfile",
                 platform=Platform.LINUX_AMD64,
             ),
-            memory_size=memory,
-            reserved_concurrent_executions=concurrent,
-            timeout=Duration.seconds(timeout),
+            memory_size=app_settings.memory,
+            reserved_concurrent_executions=app_settings.max_concurrent,
+            timeout=Duration.seconds(app_settings.timeout),
             environment=lambda_env,
             log_retention=logs.RetentionDays.ONE_WEEK,
             role=iam_reader_role,
-            tracing=aws_lambda.Tracing.ACTIVE,
+            tracing=aws_lambda.Tracing.ACTIVE
+            if app_settings.telemetry_enabled
+            else aws_lambda.Tracing.DISABLED,
         )
 
-        for perm in permissions:
-            lambda_function.add_to_role_policy(perm)
+        if app_settings.buckets:
+            for bucket in app_settings.buckets:
+                lambda_function.add_to_role_policy(
+                    iam.PolicyStatement(
+                        actions=["s3:GetObject"],
+                        resources=[f"arn:aws:s3:::{bucket}*"],
+                    )
+                )
 
         api = apigw.HttpApi(
             self,
@@ -161,23 +182,11 @@ if stack_settings.bootstrap_qualifier:
         "@aws-cdk/core:bootstrapQualifier", stack_settings.bootstrap_qualifier
     )
 
-perms = []
-if app_settings.buckets:
-    perms.append(
-        iam.PolicyStatement(
-            actions=["s3:GetObject"],
-            resources=[f"arn:aws:s3:::{bucket}*" for bucket in app_settings.buckets],
-        )
-    )
-
 lambda_stack = LambdaStack(
     app,
     f"{app_settings.name}-{stack_settings.stage}",
-    memory=app_settings.memory,
-    timeout=app_settings.timeout,
-    concurrent=app_settings.max_concurrent,
-    role_arn=app_settings.role_arn,
-    permissions=perms,
+    app_settings=app_settings,
+    stack_settings=stack_settings,
 )
 # Tag infrastructure
 for key, value in {

--- a/infrastructure/aws/cdk/config.py
+++ b/infrastructure/aws/cdk/config.py
@@ -1,25 +1,25 @@
 """STACK Configs."""
 
-from typing import List, Optional
+from typing import List
 
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class StackSettings(BaseSettings):
     """Stack settings"""
 
-    veda_custom_host: Optional[str] = None
+    veda_custom_host: str | None = None
     stage: str = "production"
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
-    bootstrap_qualifier: Optional[str] = Field(
+    bootstrap_qualifier: str | None = Field(
         None,
         description="Custom bootstrap qualifier override if not using a default installation of AWS CDK Toolkit to synthesize app.",
     )
 
-    permissions_boundary_policy_name: Optional[str] = Field(
+    permissions_boundary_policy_name: str | None = Field(
         None,
         description="Name of IAM policy to define stack permissions boundary",
     )
@@ -30,9 +30,9 @@ class AppSettings(BaseSettings):
 
     name: str = "titiler-cmr"
 
-    owner: Optional[str] = None
-    client: Optional[str] = None
-    project: Optional[str] = None
+    owner: str | None = None
+    client: str | None = None
+    project: str | None = None
 
     # S3 bucket names where TiTiler could do HEAD and GET Requests
     # specific private and public buckets MUST be added if you want to use s3:// urls
@@ -46,16 +46,31 @@ class AppSettings(BaseSettings):
     timeout: int = 30
     memory: int = 10240
 
-    role_arn: Optional[str] = None
+    role_arn: str | None = None
 
     # The maximum of concurrent executions you want to reserve for the function.
     # Default: - No specific limit - account limit.
-    max_concurrent: Optional[int] = None
-    alarm_email: Optional[str] = None
-    root_path: Optional[str] = None
-    s3_auth_strategy: Optional[str] = "environment"
-    aws_request_payer: Optional[str] = None
+    max_concurrent: int | None = None
+    alarm_email: str | None = None
+    root_path: str | None = None
+    s3_auth_strategy: str | None = "environment"
+    earthdata_username: str | None = Field(None, validation_alias="EARTHDATA_USERNAME")
+    earthdata_password: str | None = Field(None, validation_alias="EARTHDATA_PASSWORD")
+
+    aws_request_payer: str | None = None
+    telemetry_enabled: bool = True
 
     model_config = SettingsConfigDict(
         env_prefix="TITILER_CMR_", env_file=".env", extra="ignore"
     )
+
+    @model_validator(mode="after")
+    def validate_earthdata_creds(self):
+        """Validate earthdata credentials and s3 auth strategy"""
+        if self.s3_auth_strategy == "environment":
+            if not (self.earthdata_username and self.earthdata_password):
+                raise ValueError(
+                    "If TITILER_CMR_S3_AUTH_STRATEGY is set to 'environment' you must provide "
+                    "EARTHDATA_USERNAME and EARTHDATA_PASSWORD"
+                )
+        return self

--- a/titiler/cmr/main.py
+++ b/titiler/cmr/main.py
@@ -11,6 +11,9 @@ import requests
 from fastapi import FastAPI, HTTPException
 from starlette.middleware.cors import CORSMiddleware
 from starlette.templating import Jinja2Templates
+from titiler.core.errors import DEFAULT_STATUS_CODES, add_exception_handlers
+from titiler.core.middleware import CacheControlMiddleware, LoggerMiddleware
+from titiler.mosaic.errors import MOSAIC_STATUS_CODES
 
 from titiler.cmr import __version__ as titiler_cmr_version
 from titiler.cmr.backend import AWSCredentials
@@ -20,9 +23,6 @@ from titiler.cmr.logger import configure_logging, logger
 from titiler.cmr.settings import ApiSettings, AuthSettings
 from titiler.cmr.timeseries import TimeseriesExtension
 from titiler.cmr.utils import retry
-from titiler.core.errors import DEFAULT_STATUS_CODES, add_exception_handlers
-from titiler.core.middleware import CacheControlMiddleware, LoggerMiddleware
-from titiler.mosaic.errors import MOSAIC_STATUS_CODES
 
 # Configure logging at application startup
 configure_logging()


### PR DESCRIPTION
This is the follow-up infrastructure PR to #112. 

I updated the deploy-dev.yml file to use a new GitHub Environment (`dev`) where the relevant deployment settings can be managed (instead of hard-coded in the deploy-dev.yml). I created a new EDL account (username `titilercmr`) and put the credentials in the `dev` environment in GitHub.

While I was in there I also cleaned up some things in the CDK app.py file and started chipping away at #110 in config.py.

Resolves #119