### PR TITLE
fix: load S3 credentials and pass to openers in compatibility endpoint

### DIFF
--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -289,4 +289,4 @@ class TestConceptCompatibility:
             evaluate_concept_compatibility("C1234-TEST", mock_request, mock_auth)
 
         assert exc_info.value.status_code == 400
-        assert "cannot parse concept_id" in exc_info.value.detail
+        assert "Could not open a sample granule" in exc_info.value.detail

--- a/titiler/cmr/compatibility.py
+++ b/titiler/cmr/compatibility.py
@@ -3,12 +3,15 @@
 from typing import Any, Dict, List, Literal, Optional
 
 import numpy as np
+import rasterio
 from fastapi import HTTPException
 from pydantic import BaseModel
+from rasterio.session import AWSSession
 from rio_tiler.constants import WEB_MERCATOR_TMS
 from rio_tiler.io.rasterio import Reader
 from rio_tiler.models import Info
 from starlette.requests import Request
+from titiler.xarray.io import Reader as XarrayReader
 
 from titiler.cmr.backend import CMRBackend
 from titiler.cmr.dependencies import ConceptID
@@ -16,7 +19,6 @@ from titiler.cmr.logger import logger
 from titiler.cmr.reader import xarray_open_dataset
 from titiler.cmr.settings import AuthSettings
 from titiler.cmr.utils import get_concept_id_umm
-from titiler.xarray.io import Reader as XarrayReader
 
 
 class VariableInfo(BaseModel):
@@ -201,7 +203,18 @@ def evaluate_xarray_compatibility(
         if not assets:
             raise ValueError("No assets found for XarrayReader")
 
-        with xarray_open_dataset(assets[0]["url"], auth=auth) as ds:
+        asset = assets[0]
+
+        s3_credentials = (
+            src_dst.get_s3_credentials(endpoint)
+            if src_dst.get_s3_credentials
+            and (endpoint := asset.get("s3_credentials_url", None))
+            else None
+        )
+
+        with xarray_open_dataset(
+            assets[0]["url"], auth=auth, s3_credentials=s3_credentials
+        ) as ds:
             result = extract_xarray_metadata(ds)
             result["example_assets"] = assets[0]["url"]
             return result
@@ -250,11 +263,33 @@ def evaluate_rasterio_compatibility(
         if not assets:
             raise ValueError("No assets found for MultiFilesBandsReader")
 
+        s3_credentials = (
+            src_dst.get_s3_credentials(endpoint)
+            if src_dst.get_s3_credentials
+            and (endpoint := assets[0].get("s3_credentials_url", None))
+            else None
+        )
+
         example_assets: Dict[str, str] = assets[0]["url"]
 
-        with src_dst.reader(
-            input=list(example_assets.values())[0], tms=src_dst.tms
-        ) as _src_dst:
+        session = (
+            AWSSession(
+                aws_access_key_id=s3_credentials["accessKeyId"],
+                aws_secret_access_key=s3_credentials["secretAccessKey"],
+                aws_session_token=s3_credentials["sessionToken"],
+            )
+            if s3_credentials
+            else None
+        )
+        with (
+            rasterio.Env(
+                session,
+            ),
+            src_dst.reader(
+                input=list(example_assets.values())[0],
+                tms=src_dst.tms,
+            ) as _src_dst,
+        ):
             info = _src_dst.info()
 
         return {

--- a/titiler/cmr/compatibility.py
+++ b/titiler/cmr/compatibility.py
@@ -213,7 +213,7 @@ def evaluate_xarray_compatibility(
         )
 
         with xarray_open_dataset(
-            assets[0]["url"],
+            asset["url"],
             auth=auth,
             s3_credentials={
                 "key": s3_credentials["accessKeyId"],
@@ -224,7 +224,7 @@ def evaluate_xarray_compatibility(
             else None,
         ) as ds:
             result = extract_xarray_metadata(ds)
-            result["example_assets"] = assets[0]["url"]
+            result["example_assets"] = asset["url"]
             return result
 
 

--- a/titiler/cmr/compatibility.py
+++ b/titiler/cmr/compatibility.py
@@ -213,7 +213,15 @@ def evaluate_xarray_compatibility(
         )
 
         with xarray_open_dataset(
-            assets[0]["url"], auth=auth, s3_credentials=s3_credentials
+            assets[0]["url"],
+            auth=auth,
+            s3_credentials={
+                "key": s3_credentials["accessKeyId"],
+                "secret": s3_credentials["secretAccessKey"],
+                "token": s3_credentials["sessionToken"],
+            }
+            if s3_credentials
+            else None,
         ) as ds:
             result = extract_xarray_metadata(ds)
             result["example_assets"] = assets[0]["url"]

--- a/titiler/cmr/compatibility.py
+++ b/titiler/cmr/compatibility.py
@@ -341,6 +341,7 @@ def evaluate_concept_compatibility(
             **result,
         )
     except (ValueError, HTTPException, OSError, KeyError) as e:
+        xarray_error = e
         logger.warning(f"XarrayReader failed: {e}")
 
     # Fall back to rasterio
@@ -352,7 +353,13 @@ def evaluate_concept_compatibility(
             **result,
         )
     except (ValueError, HTTPException, OSError, KeyError) as e:
+        rasterio_error = e
         logger.warning(f"MultiFilesBandsReader failed: {e}")
 
     # Both failed
-    raise HTTPException(400, f"cannot parse concept_id {concept_id}")
+    raise HTTPException(
+        400,
+        f"Could not open a sample granule for concept_id {concept_id} "
+        "with either the rasterio or xarray backends.\n\n "
+        f"xarray error: {xarray_error} \n\n rasterio_error: {rasterio_error}",
+    )


### PR DESCRIPTION
The compatibility endpoints do a very basic check to see if the first asset from the first granule be opened with either the xarray or the rasterio backends. This PR collects the S3 credentials via CMRBackend.get_s3_credentials and passes them onto the opening test accordingly.

resolves #130