### PR TITLE
Strip unused botocore services from Lambda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,13 @@ EOF
 WORKDIR /app
 
 COPY pyproject.toml uv.lock README.md LICENSE ./
-RUN uv sync --no-dev --frozen --extra uvicorn
+RUN <<EOF
+uv sync --no-dev --frozen --extra uvicorn
+# Remove *.dist-info directories
+find .venv/lib/python3.12/site-packages -mindepth 1 -maxdepth 1 -type d -name '*.dist-info' -exec rm -rf {} \;
+# Remove unused botocore services (we are using only s3, so that stays)
+find .venv/lib/python3.12/site-packages/botocore/data -mindepth 1 -maxdepth 1 -not -path "*/s3" -exec rm -rf {} \;
+EOF
 
 COPY titiler ./titiler
 

--- a/infrastructure/aws/lambda/Dockerfile
+++ b/infrastructure/aws/lambda/Dockerfile
@@ -55,7 +55,12 @@ find . -name 'README*' -delete
 find . -name '*.md' -delete
 # Strip debug symbols from shared libraries (preserve numpy.libs)
 find . -type f -name '*.so*' -not -path "*/numpy.libs/*" -exec strip --strip-unneeded {} \; 2>/dev/null || true
+# Remove *.dist-info directories
+find /deps -mindepth 1 -maxdepth 1 -type d -name '*.dist-info' -exec rm -rf {} \;
+# Remove unused botocore services (we are using only s3, so that stays)
+find /deps/botocore/data -mindepth 1 -maxdepth 1 -not -path "*/s3" -exec rm -rf {} \;
 EOF
+
 
 # Stage 3: Final runtime stage - minimal Lambda image optimized for container runtime
 FROM public.ecr.aws/lambda/python:${PYTHON_VERSION}

--- a/titiler/cmr/logger.py
+++ b/titiler/cmr/logger.py
@@ -18,9 +18,9 @@ class JSONFormatter(logging.Formatter):
             "timestamp": datetime.fromtimestamp(
                 record.created, tz=timezone.utc
             ).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            "thread": record.thread,
             "level": record.levelname,
             "logger": record.name,
-            "threadName": record.threadName,
             "message": record.getMessage(),
             "filename": record.filename,
             "lineno": record.lineno,


### PR DESCRIPTION
This got the installed deps in the Lambda container from 275M down to 247M. This should suffice to unblock #139.

I added the same lines to our dev Dockerfile as well, so I could test locally that stripping things down didn't break anything.

(I also tweaked local logging output to better aid local debugging.)

Fixes #138