### PR TITLE
feat: add MVT endpoint for granule footprints (closes #153)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "h5py>=3.15.1",
     "httpx>=0.28.1",
     "isodate>=0.7.2",
+    "mapbox-vector-tile>=2.2.0",
     "obspec-utils>=0.9.0",
     "pillow>=12.1.1",
     "psutil>=7.2.2",

--- a/titiler/cmr/factory.py
+++ b/titiler/cmr/factory.py
@@ -1,11 +1,13 @@
 """titiler.cmr.factory: router factories."""
 
 import logging
-from typing import Annotated, Callable, Literal
+from typing import Annotated, Callable, Literal, Union
 
 import morecantile
 from attrs import define, field
 from fastapi import APIRouter, Depends, Path, Query
+from fastapi.responses import Response
+from shapely.geometry import box, shape
 from rio_tiler.constants import WGS84_CRS
 from titiler.core.dependencies import (
     DatasetParams as RasterioDatasetParams,
@@ -23,6 +25,7 @@ from titiler.xarray.dependencies import (
 )
 
 from titiler.cmr.backend import CMRBackend
+from titiler.cmr.enums import MediaType
 from titiler.cmr.dependencies import (
     BackendParams,
     CMRAssetsParams,
@@ -82,6 +85,18 @@ class CMRTilerFactory(BaseFactory):
 
         if self.add_ogc_maps:
             self.ogc_maps()
+
+
+def _fmt_temporal(t) -> str:
+    """Format GranuleTemporalExtent to a readable date range string."""
+    if t is None:
+        return "—"
+    rdt = getattr(t, "range_date_time", None)
+    if rdt is None:
+        return "—"
+    start = getattr(rdt, "beginning_date_time", None) or "?"
+    end = getattr(rdt, "ending_date_time", None) or "?"
+    return f"{start} / {end}"
 
 
 ###############################################################################
@@ -197,10 +212,10 @@ def assets_for_tile(
     backend_params=Depends(BackendParams),
     assets_accessor_params=Depends(GranuleSearchBackendParams),
     f: Annotated[
-        Literal["json", "geojson"],
+        Literal["json", "geojson", "mvt"],
         Query(description="Response format"),
     ] = "json",
-) -> list[Granule] | GranuleFeatureCollection:
+) -> Union[list[Granule], GranuleFeatureCollection, Response]:
     """Return granules overlapping a tile."""
     logger.info("assets_for_tile: querying CMR for granules in tile")
     tms = morecantile.tms.get(tileMatrixSetId)
@@ -216,5 +231,42 @@ def assets_for_tile(
             z,
             **assets_accessor_params.as_dict(),
         )
+
+    if f == "mvt":
+        import mapbox_vector_tile
+
+        bounds = tms.bounds(morecantile.Tile(x, y, z))
+        tile_box = box(bounds.left, bounds.bottom, bounds.right, bounds.top)
+        features = []
+        for g in granules:
+            if not g.geometry:
+                continue
+            geom = shape(
+                g.geometry if isinstance(g.geometry, dict) else g.geometry.model_dump()
+            )
+            clipped = geom.intersection(tile_box)
+            if not clipped.is_empty:
+                features.append(
+                    {
+                        "geometry": clipped.wkt,
+                        "properties": {
+                            "id": g.id,
+                            "temporal": _fmt_temporal(g.temporal_extent),
+                        },
+                    }
+                )
+        mvt_data = mapbox_vector_tile.encode(
+            [{"name": "granules", "features": features}],
+            default_options={
+                "quantize_bounds": (
+                    bounds.left,
+                    bounds.bottom,
+                    bounds.right,
+                    bounds.top,
+                ),
+                "extents": 4096,
+            },
+        )
+        return Response(content=mvt_data, media_type=MediaType.mvt)
 
     return granules_to_feature_collection(granules) if f == "geojson" else granules

--- a/uv.lock
+++ b/uv.lock
@@ -2234,6 +2234,20 @@ wheels = [
 ]
 
 [[package]]
+name = "mapbox-vector-tile"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+    { name = "pyclipper" },
+    { name = "shapely" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e0/b511bd7433105d363f37bb83f00a6e15502b04ebcec68c25e3da630d2b53/mapbox_vector_tile-2.2.0.tar.gz", hash = "sha256:9fbf2e94890429ccdaf8e047019dccadd9deb03f5b2ae9b5c5561d27a20a0eb3", size = 26038, upload-time = "2025-07-08T02:20:09.532Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/79/cb2a50533c9c3b545eace2deffba0d002b56713c68b26b6ac1e53a4c1d18/mapbox_vector_tile-2.2.0-py3-none-any.whl", hash = "sha256:d26ad320ade60cc6c0b66edc6ee4b6f53663aedf0b444b115c6ba68e9ba1e6d1", size = 23986, upload-time = "2025-07-08T02:20:08.415Z" },
+]
+
+[[package]]
 name = "markdown"
 version = "3.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3793,6 +3807,36 @@ wheels = [
 ]
 
 [[package]]
+name = "pyclipper"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/21/3c06205bb407e1f79b73b7b4dfb3950bd9537c4f625a68ab5cc41177f5bc/pyclipper-1.4.0.tar.gz", hash = "sha256:9882bd889f27da78add4dd6f881d25697efc740bf840274e749988d25496c8e1", size = 54489, upload-time = "2025-12-01T13:15:35.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/1b/7a07b68e0842324d46c03e512d8eefa9cb92ba2a792b3b4ebf939dafcac3/pyclipper-1.4.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:222ac96c8b8281b53d695b9c4fedc674f56d6d4320ad23f1bdbd168f4e316140", size = 265676, upload-time = "2025-12-01T13:15:04.15Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/dd/8bd622521c05d04963420ae6664093f154343ed044c53ea260a310c8bb4d/pyclipper-1.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f3672dbafbb458f1b96e1ee3e610d174acb5ace5bd2ed5d1252603bb797f2fc6", size = 140458, upload-time = "2025-12-01T13:15:05.76Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/06/6e3e241882bf7d6ab23d9c69ba4e85f1ec47397cbbeee948a16cf75e21ed/pyclipper-1.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d1f807e2b4760a8e5c6d6b4e8c1d71ef52b7fe1946ff088f4fa41e16a881a5ca", size = 978235, upload-time = "2025-12-01T13:15:06.993Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/f4/3418c1cd5eea640a9fa2501d4bc0b3655fa8d40145d1a4f484b987990a75/pyclipper-1.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce1f83c9a4e10ea3de1959f0ae79e9a5bd41346dff648fee6228ba9eaf8b3872", size = 961388, upload-time = "2025-12-01T13:15:08.467Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/94/c85401d24be634af529c962dd5d781f3cb62a67cd769534df2cb3feee97a/pyclipper-1.4.0-cp312-cp312-win32.whl", hash = "sha256:3ef44b64666ebf1cb521a08a60c3e639d21b8c50bfbe846ba7c52a0415e936f4", size = 95169, upload-time = "2025-12-01T13:15:10.098Z" },
+    { url = "https://files.pythonhosted.org/packages/97/77/dfea08e3b230b82ee22543c30c35d33d42f846a77f96caf7c504dd54fab1/pyclipper-1.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:d1e5498d883b706a4ce636247f0d830c6eb34a25b843a1b78e2c969754ca9037", size = 104619, upload-time = "2025-12-01T13:15:11.592Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/cbce7d47de1e6458f66a4d999b091640134deb8f2c7351eab993b70d2e10/pyclipper-1.4.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d49df13cbb2627ccb13a1046f3ea6ebf7177b5504ec61bdef87d6a704046fd6e", size = 264342, upload-time = "2025-12-01T13:15:12.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/cc/742b9d69d96c58ac156947e1b56d0f81cbacbccf869e2ac7229f2f86dc4e/pyclipper-1.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:37bfec361e174110cdddffd5ecd070a8064015c99383d95eb692c253951eee8a", size = 139839, upload-time = "2025-12-01T13:15:13.911Z" },
+    { url = "https://files.pythonhosted.org/packages/db/48/dd301d62c1529efdd721b47b9e5fb52120fcdac5f4d3405cfc0d2f391414/pyclipper-1.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:14c8bdb5a72004b721c4e6f448d2c2262d74a7f0c9e3076aeff41e564a92389f", size = 972142, upload-time = "2025-12-01T13:15:15.477Z" },
+    { url = "https://files.pythonhosted.org/packages/07/bf/d493fd1b33bb090fa64e28c1009374d5d72fa705f9331cd56517c35e381e/pyclipper-1.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f2a50c22c3a78cb4e48347ecf06930f61ce98cf9252f2e292aa025471e9d75b1", size = 952789, upload-time = "2025-12-01T13:15:17.042Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/88/b95ea8ea21ddca34aa14b123226a81526dd2faaa993f9aabd3ed21231604/pyclipper-1.4.0-cp313-cp313-win32.whl", hash = "sha256:c9a3faa416ff536cee93417a72bfb690d9dea136dc39a39dbbe1e5dadf108c9c", size = 94817, upload-time = "2025-12-01T13:15:18.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/42/0a1920d276a0e1ca21dc0d13ee9e3ba10a9a8aa3abac76cd5e5a9f503306/pyclipper-1.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:d4b2d7c41086f1927d14947c563dfc7beed2f6c0d9af13c42fe3dcdc20d35832", size = 104007, upload-time = "2025-12-01T13:15:19.763Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/20/04d58c70f3ccd404f179f8dd81d16722a05a3bf1ab61445ee64e8218c1f8/pyclipper-1.4.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:7c87480fc91a5af4c1ba310bdb7de2f089a3eeef5fe351a3cedc37da1fcced1c", size = 265167, upload-time = "2025-12-01T13:15:20.844Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2e/a570c1abe69b7260ca0caab4236ce6ea3661193ebf8d1bd7f78ccce537a5/pyclipper-1.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:81d8bb2d1fb9d66dc7ea4373b176bb4b02443a7e328b3b603a73faec088b952e", size = 139966, upload-time = "2025-12-01T13:15:22.036Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/3b/e0859e54adabdde8a24a29d3f525ebb31c71ddf2e8d93edce83a3c212ffc/pyclipper-1.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:773c0e06b683214dcfc6711be230c83b03cddebe8a57eae053d4603dd63582f9", size = 968216, upload-time = "2025-12-01T13:15:23.18Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6b/e3c4febf0a35ae643ee579b09988dd931602b5bf311020535fd9e5b7e715/pyclipper-1.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9bc45f2463d997848450dbed91c950ca37c6cf27f84a49a5cad4affc0b469e39", size = 954198, upload-time = "2025-12-01T13:15:24.522Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/74/728efcee02e12acb486ce9d56fa037120c9bf5b77c54bbdbaa441c14a9d9/pyclipper-1.4.0-cp314-cp314-win32.whl", hash = "sha256:0b8c2105b3b3c44dbe1a266f64309407fe30bf372cf39a94dc8aaa97df00da5b", size = 96951, upload-time = "2025-12-01T13:15:25.79Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d7/7f4354e69f10a917e5c7d5d72a499ef2e10945312f5e72c414a0a08d2ae4/pyclipper-1.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:6c317e182590c88ec0194149995e3d71a979cfef3b246383f4e035f9d4a11826", size = 106782, upload-time = "2025-12-01T13:15:26.945Z" },
+    { url = "https://files.pythonhosted.org/packages/63/60/fc32c7a3d7f61a970511ec2857ecd09693d8ac80d560ee7b8e67a6d268c9/pyclipper-1.4.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f160a2c6ba036f7eaf09f1f10f4fbfa734234af9112fb5187877efed78df9303", size = 269880, upload-time = "2025-12-01T13:15:28.117Z" },
+    { url = "https://files.pythonhosted.org/packages/49/df/c4a72d3f62f0ba03ec440c4fff56cd2d674a4334d23c5064cbf41c9583f6/pyclipper-1.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a9f11ad133257c52c40d50de7a0ca3370a0cdd8e3d11eec0604ad3c34ba549e9", size = 141706, upload-time = "2025-12-01T13:15:30.134Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/0b/cf55df03e2175e1e2da9db585241401e0bc98f76bee3791bed39d0313449/pyclipper-1.4.0-cp314-cp314t-win32.whl", hash = "sha256:bbc827b77442c99deaeee26e0e7f172355ddb097a5e126aea206d447d3b26286", size = 105308, upload-time = "2025-12-01T13:15:31.225Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/dc/53df8b6931d47080b4fe4ee8450d42e660ee1c5c1556c7ab73359182b769/pyclipper-1.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:29dae3e0296dff8502eeb7639fcfee794b0eec8590ba3563aee28db269da6b04", size = 117608, upload-time = "2025-12-01T13:15:32.69Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4885,6 +4929,7 @@ dependencies = [
     { name = "h5py" },
     { name = "httpx" },
     { name = "isodate" },
+    { name = "mapbox-vector-tile" },
     { name = "obspec-utils" },
     { name = "pillow" },
     { name = "psutil" },
@@ -4963,6 +5008,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "isodate", specifier = ">=0.7.2" },
     { name = "mangum", marker = "extra == 'lambda'", specifier = "==0.19.0" },
+    { name = "mapbox-vector-tile", specifier = ">=2.2.0" },
     { name = "obspec-utils", specifier = ">=0.9.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'lambda'", specifier = ">=1.40.0" },
     { name = "opentelemetry-instrumentation-fastapi", marker = "extra == 'lambda'", specifier = ">=0.61b0" },


### PR DESCRIPTION
## Summary

Closes #153

The existing granule endpoints return GeoJSON which loads all data at once — inefficient for map visualization at scale. This PR adds `f=mvt` support to the existing tile endpoint so clients can fetch only the granules visible in the current viewport as binary vector tiles.

### Backend changes
- Added `f=mvt` option to `GET /tiles/{tms}/{z}/{x}/{y}/granules`
- Granule geometries are clipped to tile bounds using `shapely` before encoding
- Binary MVT response encoded via `mapbox-vector-tile`
- All existing CMR query parameters (`collection_concept_id`, `temporal`, etc.) supported
- Added `mapbox-vector-tile>=2.2.0` to dependencies

### Frontend demo
Added `docs/api/granule_vector_tiles_demo/` — a standalone MapLibre GL JS demo that:
- Fetches only tiles visible in the current viewport
- Shows live stats: visible granules, tiles fetched, zoom level
- Supports any CMR collection universally
- Links each granule popup to its CMR metadata

Tested with ECCO Sea Ice Velocity and MUR SST (Global) collections.
