### PR TITLE
chore: ci upgrades and security fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,27 @@
 version: 2
 updates:
+  - package-ecosystem: uv
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      all:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps):"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     cooldown:
       default-days: 7
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: monthly
     groups:
-      minor-and-patch:
-        applies-to: version-updates
+      all:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
+    commit-message:
+      prefix: "ci(deps):"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,12 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        # zizmor: ignore[artipacked]
+        # This workflow commits benchmark results via git push, so
+        # persisted credentials are required for the push step.
 
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.11.*"
-          enable-cache: true
+          enable-cache: false
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,60 +1,76 @@
-name: Test
+name: CI
 
-# Triggers on pushes to main, dev and tags.
 on:
-  workflow_dispatch:
   push:
-    branches:
-      - main
-      - develop
+    branches: [main, develop]
     tags:
       - 'v*'
     paths:
-      # Only run test and docker publish if some code have changed
       - 'pyproject.toml'
       - 'infrastructure/aws/**'
       - 'titiler/**'
       - '.pre-commit-config.yaml'
       - '.github/workflows/ci.yml'
-
-  # Run tests on pull requests.
   pull_request:
+    branches: [main, develop]
+
+permissions: {}
+
 env:
   LATEST_PY_VERSION: '3.13'
-  UV_FROZEN: 'true'
-  UV_NO_PROGRESS: 'true'
-
-permissions:
-  id-token: write   # This is required for requesting the JWT
-  contents: read    # This is required for actions/checkout
 
 jobs:
-  tests:
+  lint-python:
+    name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.*"
+          enable-cache: false
+
+      - name: Set up Python
+        run: uv python install ${{ env.LATEST_PY_VERSION }}
+
+      - name: Check docs
+        run: uv run mkdocs build --strict
+
+      - uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
+
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ['3.12', '3.13']
-
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: "0.10.*"
-          enable-cache: true
+          version: "0.11.*"
+          enable-cache: false
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: |
-          uv sync --all-extras
+        run: uv sync --all-extras
 
-      - name: run pre-commit
-        if: ${{ matrix.python-version == env.LATEST_PY_VERSION }}
-        run: |
-          uv run pre-commit run --all-files
+      - name: Run pre-commit
+        if: matrix.python-version == env.LATEST_PY_VERSION
+        run: uv run pre-commit run --all-files
 
       - name: Run tests
         run: uv run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
         run: uv python install ${{ env.LATEST_PY_VERSION }}
 
       - name: Check docs
+        env:
+          MKDOCS_JUPYTER_EXECUTE: "false"
         run: uv run mkdocs build --strict
 
       - uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
     tags:
       - 'v*'
     paths:
@@ -12,7 +12,7 @@ on:
       - '.pre-commit-config.yaml'
       - '.github/workflows/ci.yml'
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 permissions: {}
 

--- a/.github/workflows/conventional-commits-prs.yml
+++ b/.github/workflows/conventional-commits-prs.yml
@@ -1,0 +1,23 @@
+name: PR Conventional Commit Validation
+
+# NOTE: pull_request_target runs in the base repo context with access to secrets.
+# Do NOT checkout untrusted code in this workflow.
+on:
+  # zizmor: ignore[dangerous-triggers]
+  # Safe: this workflow does not check out any code; it only validates
+  # the PR title via the GitHub API.
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited]
+
+permissions: {}
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: PR Conventional Commit Validation
+        uses: ytanikin/pr-conventional-commits@639145d78959c53c43112365837e3abd21ed67c1 # 1.5.2
+        with:
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,4 +1,4 @@
-name: CDK Deploy Dev Workflow 🚀
+name: CDK Deploy Dev Workflow
 
 permissions:
   id-token: write
@@ -16,7 +16,7 @@ on:
 
 jobs:
   deploy:
-    name: Deploy to dev 🚀
+    name: Deploy to dev
     runs-on: ubuntu-latest
     environment: dev
     if: >
@@ -45,6 +45,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ steps.set_branch.outputs.branch }}
+          persist-credentials: false
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,17 +2,19 @@ name: Documentation
 on:
   push:
     branches:
-      - develop
+      - main
     tags:
       - 'v*'
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to deploy (e.g., 0.1.4, "dev" for develop branch, or branch name like "feat/reorg-documentation")'
+        description: 'Version to deploy (e.g., 0.1.4, "dev" for develop branch, or
+          branch name like "feat/reorg-documentation")'
         required: true
         type: string
       titiler_cmr_endpoint:
-        description: 'titiler-cmr API endpoint used when executing notebooks (default: production, use "staging" for staging, or provide a full URL)'
+        description: 'titiler-cmr API endpoint used when executing notebooks (default:
+          production, use "staging" for staging, or provide a full URL)'
         required: false
         default: 'https://openveda.cloud/api/titiler-cmr'
         type: string
@@ -30,14 +32,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        # zizmor: ignore[artipacked]
+        # This workflow uses mike to push to gh-pages via git, so persisted
+        # credentials are required for the subsequent git operations.
         with:
-          fetch-depth: 0  # Important for mike to work with tags
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.version != 'dev' && (startsWith(inputs.version, 'v') || contains(inputs.version, '/')) && inputs.version || github.event_name == 'workflow_dispatch' && inputs.version != 'dev' && format('v{0}', inputs.version) || github.ref }}
+          fetch-depth: 0 # Important for mike to work with tags
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.version != 'dev' &&
+            (startsWith(inputs.version, 'v') || contains(inputs.version, '/'))
+            && inputs.version || github.event_name == 'workflow_dispatch' &&
+            inputs.version != 'dev' && format('v{0}', inputs.version) ||
+            github.ref }}
 
-      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: "0.9.*"
-          enable-cache: true
+          version: "0.11.*"
+          enable-cache: false
+
       - name: Sync
         run: |
           uv sync
@@ -52,18 +62,25 @@ jobs:
       - name: Fetch gh-pages branch
         run: |
           git fetch origin gh-pages --depth=1 || true
-      
+
       - name: Deploy docs
         env:
           EARTHDATA_USERNAME: ${{ secrets.earthdata_username }}
           EARTHDATA_PASSWORD: ${{ secrets.earthdata_password }}
-          TITILER_CMR_ENDPOINT: ${{ inputs.titiler_cmr_endpoint == 'staging' && 'https://staging.openveda.cloud/api/titiler-cmr' || inputs.titiler_cmr_endpoint || 'https://openveda.cloud/api/titiler-cmr' }}
+          TITILER_CMR_ENDPOINT: ${{ inputs.titiler_cmr_endpoint == 'staging' &&
+            'https://staging.openveda.cloud/api/titiler-cmr' ||
+            inputs.titiler_cmr_endpoint ||
+            'https://openveda.cloud/api/titiler-cmr' }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          echo "machine urs.earthdata.nasa.gov\nlogin ${EARTHDATA_USERNAME}\npassword ${EARTHDATA_PASSWORD}" > ~/.netrc
+          echo "machine urs.earthdata.nasa.gov
+          login ${EARTHDATA_USERNAME}
+          password ${EARTHDATA_PASSWORD}" > ~/.netrc
 
           # Handle manual workflow dispatch
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            VERSION="${{ inputs.version }}"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            VERSION="$INPUT_VERSION"
             if [[ "$VERSION" == "dev" ]]; then
               uv run mike deploy --push --update-aliases dev
               uv run mike set-default --push dev
@@ -72,27 +89,27 @@ jobs:
               # Sanitize branch name for use as mike version (replace / with -)
               SAFE_VERSION=$(echo "$VERSION" | sed 's/\//-/g')
               echo "Deploying branch version: $SAFE_VERSION"
-              uv run mike deploy --push $SAFE_VERSION
+              uv run mike deploy --push "$SAFE_VERSION"
             else
               # Assume it's a version number
-              uv run mike deploy --push $VERSION
+              uv run mike deploy --push "$VERSION"
 
               # Check if this should be the latest version
               LATEST_TAG=$(git tag --sort=-creatordate | head -n 1)
               if [[ "v$VERSION" == "$LATEST_TAG" ]]; then
-                uv run mike alias --push --update-aliases $VERSION latest
+                uv run mike alias --push --update-aliases "$VERSION" latest
               fi
             fi
-          elif [[ $GITHUB_REF == refs/tags/* ]]; then
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
             # For tags, deploy the tagged version
             VERSION=${GITHUB_REF#refs/tags/v}
-            uv run mike deploy --push $VERSION
+            uv run mike deploy --push "$VERSION"
 
             # If this is the latest version, update the 'latest' alias
             LATEST_TAG=$(git tag --sort=-creatordate | head -n 1)
-          if [[ "v$VERSION" == "$LATEST_TAG" ]]; then
-            uv run mike alias --push --update-aliases $VERSION latest
-          fi
+            if [[ "v$VERSION" == "$LATEST_TAG" ]]; then
+              uv run mike alias --push --update-aliases "$VERSION" latest
+            fi
           else
             # For develop branch, deploy to 'dev'
             uv run mike deploy --push --update-aliases dev

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,4 @@
-name: GitHub Actions Security Analysis with zizmor 🌈
+name: GitHub Actions Security Analysis with zizmor
 
 on:
   push:
@@ -19,5 +19,5 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Run zizmor 🌈
+      - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,10 @@ repos:
       - id: validate-pyproject
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.14
+    rev: v0.15.4
     hooks:
       - id: ruff
-        args: ["--fix"]
+        args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
@@ -18,8 +18,13 @@ repos:
         language_version: python
         exclude: tests/.*
         additional_dependencies:
-        - types-cachetools
-        - types-attrs
-        - types-python-dateutil
-        - types-requests
-        - pydantic>=2.4
+          - types-cachetools
+          - types-attrs
+          - types-python-dateutil
+          - types-requests
+          - pydantic>=2.4
+
+  - repo: https://github.com/tsvikas/sync-with-uv
+    rev: v0.5.0
+    hooks:
+      - id: sync-with-uv

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ uv sync --all-extras
 ## Authentication for data read access
 
 `titiler-cmr` can read data either over `HTTP` (external) or directly from `AWS S3` (direct) depending on the app configuration.
-The behavior is controlled by environment variables (or a `.env` file) read by `EarthdataSettings` and `ApiSettings` in [`titiler/cmr/settings.py`](titiler/cmr/settings.py).
+The behavior is controlled by environment variables (or a `.env` file) read by `EarthdataSettings` and `ApiSettings` in [`titiler/cmr/settings.py`](../titiler/cmr/settings.py).
 
 ### Direct from S3
 
@@ -147,11 +147,11 @@ The application will be available at this address: [http://localhost:8000/api.ht
 
 ## Deployment to AWS via `veda-deploy`
 
-Deployment to AWS is currently triggered using [veda-deploy](https://github.com/NASA-IMPACT/veda-deploy). veda-deploy checks out this repo as a submodule and then executes [.github/actions/cdk-deploy/action.yml](.github/actions/cdk-deploy/action.yml) (see also: [veda-deploy/.github/workflows/deploy.yml](https://github.com/NASA-IMPACT/veda-deploy/blob/dev/.github/workflows/deploy.yml)). For more details, please review the [veda-deploy README section on adding new components](https://github.com/NASA-IMPACT/veda-deploy/tree/dev?tab=readme-ov-file#add-new-components).
+Deployment to AWS is currently triggered using [veda-deploy](https://github.com/NASA-IMPACT/veda-deploy). veda-deploy checks out this repo as a submodule and then executes [.github/actions/cdk-deploy/action.yml](../.github/actions/cdk-deploy/action.yml) (see also: [veda-deploy/.github/workflows/deploy.yml](https://github.com/NASA-IMPACT/veda-deploy/blob/dev/.github/workflows/deploy.yml)). For more details, please review the [veda-deploy README section on adding new components](https://github.com/NASA-IMPACT/veda-deploy/tree/dev?tab=readme-ov-file#add-new-components).
 
 ### Environment Variables
 
-Environment variables for the `veda-deploy` deployment should be configured in the `veda-deploy` environment-specific AWS Secret. See also [these instructions](https://github.com/NASA-IMPACT/veda-deploy/tree/dev?tab=readme-ov-file#store-env-configuration-in-aws-secrets-manager). The variables in the AWS Secret will be written to an `.env` file and used by the CDK deployment. All settings are defined in [`titiler/cmr/settings.py`](titiler/cmr/settings.py): `StackSettings` controls CDK infrastructure (stack name, memory, timeout, etc.), `EarthdataSettings` and `ApiSettings` are read by both the CDK (to set Lambda environment variables) and the Lambda runtime itself.
+Environment variables for the `veda-deploy` deployment should be configured in the `veda-deploy` environment-specific AWS Secret. See also [these instructions](https://github.com/NASA-IMPACT/veda-deploy/tree/dev?tab=readme-ov-file#store-env-configuration-in-aws-secrets-manager). The variables in the AWS Secret will be written to an `.env` file and used by the CDK deployment. All settings are defined in [`titiler/cmr/settings.py`](../titiler/cmr/settings.py): `StackSettings` controls CDK infrastructure (stack name, memory, timeout, etc.), `EarthdataSettings` and `ApiSettings` are read by both the CDK (to set Lambda environment variables) and the Lambda runtime itself.
 
 The environment variables which should be set in the `veda-deploy` AWS secret are:
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ uv sync --all-extras
 ## Authentication for data read access
 
 `titiler-cmr` can read data either over `HTTP` (external) or directly from `AWS S3` (direct) depending on the app configuration.
-The behavior is controlled by environment variables (or a `.env` file) read by `EarthdataSettings` and `ApiSettings` in [`titiler/cmr/settings.py`](../titiler/cmr/settings.py).
+The behavior is controlled by environment variables (or a `.env` file) read by `EarthdataSettings` and `ApiSettings` in [`titiler/cmr/settings.py`](https://github.com/developmentseed/titiler-cmr/blob/main/titiler/cmr/settings.py).
 
 ### Direct from S3
 
@@ -147,11 +147,11 @@ The application will be available at this address: [http://localhost:8000/api.ht
 
 ## Deployment to AWS via `veda-deploy`
 
-Deployment to AWS is currently triggered using [veda-deploy](https://github.com/NASA-IMPACT/veda-deploy). veda-deploy checks out this repo as a submodule and then executes [.github/actions/cdk-deploy/action.yml](../.github/actions/cdk-deploy/action.yml) (see also: [veda-deploy/.github/workflows/deploy.yml](https://github.com/NASA-IMPACT/veda-deploy/blob/dev/.github/workflows/deploy.yml)). For more details, please review the [veda-deploy README section on adding new components](https://github.com/NASA-IMPACT/veda-deploy/tree/dev?tab=readme-ov-file#add-new-components).
+Deployment to AWS is currently triggered using [veda-deploy](https://github.com/NASA-IMPACT/veda-deploy). veda-deploy checks out this repo as a submodule and then executes [.github/actions/cdk-deploy/action.yml](https://github.com/developmentseed/titiler-cmr/blob/main/.github/actions/cdk-deploy/action.yml) (see also: [veda-deploy/.github/workflows/deploy.yml](https://github.com/NASA-IMPACT/veda-deploy/blob/dev/.github/workflows/deploy.yml)). For more details, please review the [veda-deploy README section on adding new components](https://github.com/NASA-IMPACT/veda-deploy/tree/dev?tab=readme-ov-file#add-new-components).
 
 ### Environment Variables
 
-Environment variables for the `veda-deploy` deployment should be configured in the `veda-deploy` environment-specific AWS Secret. See also [these instructions](https://github.com/NASA-IMPACT/veda-deploy/tree/dev?tab=readme-ov-file#store-env-configuration-in-aws-secrets-manager). The variables in the AWS Secret will be written to an `.env` file and used by the CDK deployment. All settings are defined in [`titiler/cmr/settings.py`](../titiler/cmr/settings.py): `StackSettings` controls CDK infrastructure (stack name, memory, timeout, etc.), `EarthdataSettings` and `ApiSettings` are read by both the CDK (to set Lambda environment variables) and the Lambda runtime itself.
+Environment variables for the `veda-deploy` deployment should be configured in the `veda-deploy` environment-specific AWS Secret. See also [these instructions](https://github.com/NASA-IMPACT/veda-deploy/tree/dev?tab=readme-ov-file#store-env-configuration-in-aws-secrets-manager). The variables in the AWS Secret will be written to an `.env` file and used by the CDK deployment. All settings are defined in [`titiler/cmr/settings.py`](https://github.com/developmentseed/titiler-cmr/blob/main/titiler/cmr/settings.py): `StackSettings` controls CDK infrastructure (stack name, memory, timeout, etc.), `EarthdataSettings` and `ApiSettings` are read by both the CDK (to set Lambda environment variables) and the Lambda runtime itself.
 
 The environment variables which should be set in the `veda-deploy` AWS secret are:
 

--- a/docs/conventional-commits.md
+++ b/docs/conventional-commits.md
@@ -1,0 +1,45 @@
+# Conventional Commits
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) to ensure clean, readable version history and to enable automated changelog generation.
+
+## Pull Request Requirements
+
+All PR titles must follow the Conventional Commit format:
+
+```
+<type>: <description>
+```
+
+For example:
+
+```
+feat: add support for STAC item collections
+fix: resolve NaN handling in time series output
+docs: update API examples with new backend options
+```
+
+## Supported Types
+
+The following types are accepted:
+
+- `feat` — new features or enhancements
+- `fix` — bug fixes
+- `docs` — documentation changes
+- `test` — additions or corrections to tests
+- `ci` — changes to CI/CD configuration
+- `refactor` — code changes that neither fix bugs nor add features
+- `perf` — performance improvements
+- `chore` — routine maintenance tasks (dependency updates, formatting, etc.)
+- `revert` — reverting a previous change
+
+## Why This Matters
+
+Using conventional commits allows us to:
+
+- Generate changelogs automatically
+- Determine semantic version bumps (MAJOR, MINOR, PATCH) automatically
+- Keep the project history clean and scannable
+
+## Resources
+
+- [Conventional Commits Specification](https://www.conventionalcommits.org/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,7 +57,7 @@ plugins:
   - mkdocs-jupyter:
       include_source: True
       include_requirejs: True
-      execute: True
+      execute: !ENV [MKDOCS_JUPYTER_EXECUTE, True]
       execute_ignore: ["*.py"]  # Don't execute these
       remove_tag_config:
         remove_input_tags:


### PR DESCRIPTION
This PR includes the following changes:

- add dependabot updates for the uv.lock file
- update the pins for some of the github actions
- incorporate some zizmor fixes I discovered on other projects
- add sync-with-uv pre-commit hook to keep pre-commit package versions in sync with uv