### PR TITLE
chore(docs): Link to production NASA docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ echo "machine urs.earthdata.nasa.gov login ${EARTHDATA_USERNAME} password ${EART
 ```
 
 > [!NOTE]
-> See [NASA's docs](https://uat.urs.earthdata.nasa.gov/documentation/for_users/data_access/curl_and_wget) for details
+> See [NASA's docs](https://urs.earthdata.nasa.gov/documentation/for_users/data_access/curl_and_wget) for details
 
 ## Docker deployment
 


### PR DESCRIPTION
Another completely minor edit to change the NASA docs link to the production documentation instead of UAT (User Acceptance Testing). This ensures the best, canonical documentation is available to the reader.