### PR TITLE
feat: add group inspection to compatibility endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ node_modules
 
 notebooks/
 .envrc
+issue-drafts/
 
 # Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode
 # Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ See also the [API documentation](https://staging.openveda.cloud/api/titiler-cmr/
 
 - Render tiles from assets discovered via queries to [NASA's CMR](https://cmr.earthdata.nasa.gov/search)
 - Two backends: **xarray** (`/xarray`) for NetCDF/HDF5 datasets and **rasterio** (`/rasterio`) for GeoTIFF/COG assets
+- `/compatibility` helps inspect sample granules, including optional `group` selection plus xarray group hints and `sampled_group` metadata for hierarchical HDF5 and NetCDF assets
 - Timeseries endpoints for generating GIFs, statistics, and tilejsons across a temporal range
 - Queries CMR directly via the [granule search API](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html)
 - Built on top of [titiler](https://github.com/developmentseed/titiler)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See also the [API documentation](https://staging.openveda.cloud/api/titiler-cmr/
 
 - Render tiles from assets discovered via queries to [NASA's CMR](https://cmr.earthdata.nasa.gov/search)
 - Two backends: **xarray** (`/xarray`) for NetCDF/HDF5 datasets and **rasterio** (`/rasterio`) for GeoTIFF/COG assets
-- `/compatibility` helps inspect sample granules, including optional `group` selection plus xarray group hints and `sampled_group` metadata for hierarchical HDF5 and NetCDF assets
+- `/compatibility` helps inspect sample granules, including optional `group` selection and lightweight group discovery for hierarchical HDF5 and NetCDF assets
 - Timeseries endpoints for generating GIFs, statistics, and tilejsons across a temporal range
 - Queries CMR directly via the [granule search API](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html)
 - Built on top of [titiler](https://github.com/developmentseed/titiler)

--- a/docs/api/compatibility_api_example.ipynb
+++ b/docs/api/compatibility_api_example.ipynb
@@ -27,7 +27,9 @@
     "import earthaccess\n",
     "import httpx2 as httpx\n",
     "\n",
-    "titiler_endpoint = os.getenv(\"TITILER_CMR_ENDPOINT\", \"http://localhost:8000\")"
+    "titiler_endpoint = os.getenv(\n",
+    "    \"TITILER_CMR_ENDPOINT\", \"https://staging.openveda.cloud/api/titiler-cmr\"\n",
+    ")"
    ]
   },
   {

--- a/docs/api/compatibility_api_example.ipynb
+++ b/docs/api/compatibility_api_example.ipynb
@@ -2,14 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "cdeef4c6-75b0-44d9-90d4-c850b5d8908a",
+   "id": "intro",
    "metadata": {},
    "source": [
     "# How to use the Compatibility API\n",
     "\n",
-    "The `/compatibility` endpoint displays information about the collection and returns some details about a sample granule. The output is helpful for understanding the structure of the collection and the granules so that you can craft the right set of parameters for visualization or statistics requests.\n",
+    "The `/compatibility` endpoint helps you understand how to call TiTiler-CMR for a collection. For hierarchical HDF5 and NetCDF datasets it can now also tell you when a `group` parameter is needed, suggest candidate groups, and return links that already include the sampled group when one was used to inspect the file.\n",
     "\n",
-    "This notebook demonstrates how to use the compatibility endpoint for th [GHRSST Level 4 MUR Global Foundation Sea Surface Temperature Analysis (v4.1)](https://cmr.earthdata.nasa.gov/search/concepts/C1996881146-POCLOUD) dataset.\n",
+    "This notebook demonstrates how to interpret that response for the [NISAR Beta Geocoded Polarimetric Covariance (GCOV)](https://www.earthdata.nasa.gov/data/catalog/asf-nisar-l2-gcov-beta-v1-1) collection, which is a known example of a hierarchical HDF5 dataset that needs a `group` parameter for xarray requests.\n",
     "\n",
     "## Setup"
    ]
@@ -17,59 +17,59 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d015182-5347-437a-8b66-d7d62212f0e3",
+   "id": "setup",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import json\n",
     "import os\n",
     "\n",
-    "import json\n",
     "import earthaccess\n",
     "import httpx2 as httpx\n",
     "\n",
     "titiler_endpoint = os.getenv(\n",
-    "    \"TITILER_CMR_ENDPOINT\", \"https://openveda.cloud/api/titiler-cmr\"\n",
+    "    \"TITILER_CMR_ENDPOINT\", \"https://v4jec6i5c0.execute-api.us-west-2.amazonaws.com\"\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d375b5b7-9322-4f1e-8859-000ef8ac4898",
+   "id": "identify-dataset",
    "metadata": {},
    "source": [
     "## Identify the dataset\n",
     "\n",
-    "You can find the MUR SST dataset using the `earthaccess.search_datasets` function."
+    "You can find the collection with `earthaccess.search_datasets`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f3fcc9cd-6105-42fc-98bf-2de40910a79c",
+   "id": "search-dataset",
    "metadata": {},
    "outputs": [],
    "source": [
-    "datasets = earthaccess.search_datasets(concept_id=\"C1996881146-POCLOUD\")\n",
+    "datasets = earthaccess.search_datasets(concept_id=\"C3622214170-ASF\")\n",
     "ds = datasets[0]\n",
     "\n",
     "collection_concept_id = ds[\"meta\"][\"concept-id\"]\n",
-    "print(\"CollectionConcept-Id: \", collection_concept_id)\n",
-    "\n",
-    "print(\"Abstract: \", ds[\"umm\"][\"Abstract\"])"
+    "print(\"CollectionConcept-Id:\", collection_concept_id)\n",
+    "print(\"Short name:\", ds[\"umm\"][\"ShortName\"])\n",
+    "print(\"Version:\", ds[\"umm\"][\"Version\"])"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2a4cffa6-0059-4033-a708-db60d743f0e3",
+   "id": "explore-collection",
    "metadata": {},
    "source": [
-    "## Explore the collection using the `/compatibility` endpoint"
+    "## Explore the collection using `/compatibility`"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1bde609a-26df-4f35-b7e1-9e1922e87808",
+   "id": "compatibility-request",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,12 +84,62 @@
   },
   {
    "cell_type": "markdown",
-   "id": "04014a32-9c11-4b75-b40a-e5ad4efd686b",
+   "id": "interpret-response",
    "metadata": {},
    "source": [
-    "The details from the sample granule show that it is a NetCDF file with four variables (`analysed_sst`, `analysis_error`, `mask`, and `sea_ice_fraction`) and each contains an array with a single time coordinate. The `datetime` key shows the reported temporal range from CMR which indicates that the dataset has granules from `2008-07-23` to present. For each variable several summary statistics are available to help you craft min/max values for the `rescale` parameter.\n",
+    "## Interpret the response\n",
     "\n",
-    "This information is handy for generating tiles via the tiles API, which you can learn more about in [the Tiles API Documentation](../tiling_api_xarray_backend_example)."
+    "For hierarchical datasets, the most important fields are:\n",
+    "\n",
+    "- `requires_group`: the root dataset was not enough, so xarray requests should include `group=...`\n",
+    "- `group_hints`: candidate group paths to try\n",
+    "- `default_group`: a recommended group when there is a clear single choice\n",
+    "- `sampled_group`: the group that was actually used to collect the returned metadata\n",
+    "\n",
+    "If `sampled_group` is present, the compatibility links should already include it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "summarize-response",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "group_hints = compatibility_response.get(\"group_hints\", [])\n",
+    "sampled_group = compatibility_response.get(\"sampled_group\")\n",
+    "default_group = compatibility_response.get(\"default_group\")\n",
+    "variables = list((compatibility_response.get(\"variables\") or {}).keys())\n",
+    "tilejson_link = next(\n",
+    "    link[\"href\"]\n",
+    "    for link in compatibility_response.get(\"links\", [])\n",
+    "    if link[\"rel\"] == \"tilejson\"\n",
+    ")\n",
+    "\n",
+    "print(\"requires_group:\", compatibility_response.get(\"requires_group\"))\n",
+    "print(\"group_hints:\")\n",
+    "for hint in group_hints:\n",
+    "    print(\" -\", hint)\n",
+    "print(\"default_group:\", default_group)\n",
+    "print(\"sampled_group:\", sampled_group)\n",
+    "print(\"variables (first 10):\", variables[:10])\n",
+    "print(\"tilejson link:\", tilejson_link)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "what-to-do-next",
+   "metadata": {},
+   "source": [
+    "For a grouped dataset like NISAR GCOV, the response should tell you exactly how to proceed:\n",
+    "\n",
+    "1. If `requires_group` is `true`, use a group from `group_hints`.\n",
+    "2. Prefer `default_group` when it is present.\n",
+    "3. If `default_group` is `null`, fall back to `sampled_group` or choose from `group_hints`.\n",
+    "4. Pick a variable name from `variables`.\n",
+    "5. Reuse the returned compatibility links, since they should already include the sampled group when one was needed.\n",
+    "\n",
+    "That turns the compatibility response into a practical recipe for the next xarray request instead of leaving you to guess the right group path."
    ]
   }
  ],

--- a/docs/api/compatibility_api_example.ipynb
+++ b/docs/api/compatibility_api_example.ipynb
@@ -7,9 +7,9 @@
    "source": [
     "# How to use the Compatibility API\n",
     "\n",
-    "The `/compatibility` endpoint helps you understand how to call TiTiler-CMR for a collection. For hierarchical HDF5 and NetCDF datasets it can now also tell you when a `group` parameter is needed, suggest candidate groups, and return links that already include the sampled group when one was used to inspect the file.\n",
+    "The `/compatibility` endpoint helps you understand how to call TiTiler-CMR for a collection. For hierarchical HDF5 and NetCDF datasets it can return a lightweight list of candidate `group` paths from the root request, then let you inspect variables by making a follow-up request with `group=...`.\n",
     "\n",
-    "This notebook demonstrates how to interpret that response for the [NISAR Beta Geocoded Polarimetric Covariance (GCOV)](https://www.earthdata.nasa.gov/data/catalog/asf-nisar-l2-gcov-beta-v1-1) collection, which is a known example of a hierarchical HDF5 dataset that needs a `group` parameter for xarray requests.\n",
+    "This notebook demonstrates that workflow for the [NISAR Beta Geocoded Polarimetric Covariance (GCOV)](https://www.earthdata.nasa.gov/data/catalog/asf-nisar-l2-gcov-beta-v1-1) collection, which is a known example of a hierarchical HDF5 dataset that needs a `group` parameter for xarray requests.\n",
     "\n",
     "## Setup"
    ]
@@ -27,9 +27,7 @@
     "import earthaccess\n",
     "import httpx2 as httpx\n",
     "\n",
-    "titiler_endpoint = os.getenv(\n",
-    "    \"TITILER_CMR_ENDPOINT\", \"https://v4jec6i5c0.execute-api.us-west-2.amazonaws.com\"\n",
-    ")"
+    "titiler_endpoint = os.getenv(\"TITILER_CMR_ENDPOINT\", \"http://localhost:8000\")"
    ]
   },
   {
@@ -89,14 +87,11 @@
    "source": [
     "## Interpret the response\n",
     "\n",
-    "For hierarchical datasets, the most important fields are:\n",
+    "For hierarchical datasets, a root `/compatibility` request stays lightweight. The most important field is:\n",
     "\n",
-    "- `requires_group`: the root dataset was not enough, so xarray requests should include `group=...`\n",
-    "- `group_hints`: candidate group paths to try\n",
-    "- `default_group`: a recommended group when there is a clear single choice\n",
-    "- `sampled_group`: the group that was actually used to collect the returned metadata\n",
+    "- `compatible_groups`: candidate group paths to try in a follow-up request\n",
     "\n",
-    "If `sampled_group` is present, the compatibility links should already include it."
+    "At this stage the response may not include variable metadata or xarray links yet, because TiTiler-CMR has not inspected a nested group."
    ]
   },
   {
@@ -106,24 +101,70 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "group_hints = compatibility_response.get(\"group_hints\", [])\n",
-    "sampled_group = compatibility_response.get(\"sampled_group\")\n",
-    "default_group = compatibility_response.get(\"default_group\")\n",
+    "compatible_groups = compatibility_response.get(\"compatible_groups\", [])\n",
     "variables = list((compatibility_response.get(\"variables\") or {}).keys())\n",
     "tilejson_link = next(\n",
+    "    (\n",
+    "        link[\"href\"]\n",
+    "        for link in compatibility_response.get(\"links\", [])\n",
+    "        if link[\"rel\"] == \"tilejson\"\n",
+    "    ),\n",
+    "    None,\n",
+    ")\n",
+    "\n",
+    "print(\"compatible_groups:\")\n",
+    "for group in compatible_groups:\n",
+    "    print(\" -\", group)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "inspect-explicit-group",
+   "metadata": {},
+   "source": [
+    "## Inspect a specific group\n",
+    "\n",
+    "Once you choose a group from `compatible_groups`, make a follow-up `/compatibility` request with `group=...` to inspect variables and get xarray links."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "compatibility-request-with-group",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "selected_group = compatible_groups[1]\n",
+    "\n",
+    "grouped_compatibility_response = httpx.get(\n",
+    "    f\"{titiler_endpoint}/compatibility\",\n",
+    "    params={\n",
+    "        \"collection_concept_id\": collection_concept_id,\n",
+    "        \"group\": selected_group,\n",
+    "    },\n",
+    "    timeout=30,\n",
+    ").json()\n",
+    "\n",
+    "print(json.dumps(grouped_compatibility_response, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "summarize-grouped-response",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "group_variables = list((grouped_compatibility_response.get(\"variables\") or {}).keys())\n",
+    "group_tilejson_link = next(\n",
     "    link[\"href\"]\n",
-    "    for link in compatibility_response.get(\"links\", [])\n",
+    "    for link in grouped_compatibility_response.get(\"links\", [])\n",
     "    if link[\"rel\"] == \"tilejson\"\n",
     ")\n",
     "\n",
-    "print(\"requires_group:\", compatibility_response.get(\"requires_group\"))\n",
-    "print(\"group_hints:\")\n",
-    "for hint in group_hints:\n",
-    "    print(\" -\", hint)\n",
-    "print(\"default_group:\", default_group)\n",
-    "print(\"sampled_group:\", sampled_group)\n",
-    "print(\"variables (first 10):\", variables[:10])\n",
-    "print(\"tilejson link:\", tilejson_link)"
+    "print(\"selected group:\", selected_group)\n",
+    "print(\"variables in selected group (first 10):\", group_variables[:10])\n",
+    "print(\"tilejson link for selected group:\", group_tilejson_link)"
    ]
   },
   {
@@ -131,15 +172,15 @@
    "id": "what-to-do-next",
    "metadata": {},
    "source": [
-    "For a grouped dataset like NISAR GCOV, the response should tell you exactly how to proceed:\n",
+    "For a grouped dataset like NISAR GCOV, the workflow is:\n",
     "\n",
-    "1. If `requires_group` is `true`, use a group from `group_hints`.\n",
-    "2. Prefer `default_group` when it is present.\n",
-    "3. If `default_group` is `null`, fall back to `sampled_group` or choose from `group_hints`.\n",
+    "1. Call `/compatibility` without `group` to get candidate `compatible_groups`.\n",
+    "2. Choose one of those group paths.\n",
+    "3. Call `/compatibility` again with `group=...` to inspect variables and dimensions for that group.\n",
     "4. Pick a variable name from `variables`.\n",
-    "5. Reuse the returned compatibility links, since they should already include the sampled group when one was needed.\n",
+    "5. Reuse the returned xarray links from the grouped response.\n",
     "\n",
-    "That turns the compatibility response into a practical recipe for the next xarray request instead of leaving you to guess the right group path."
+    "That keeps the root compatibility response lightweight while still giving you a practical path to the next xarray request."
    ]
   }
  ],

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -8,6 +8,9 @@ from fastapi import HTTPException
 
 from titiler.cmr.compatibility import (
     CompatibilityResponse,
+    _candidate_group_paths,
+    _dataset_dim_scale_names,
+    _group_has_spatial_dims,
     evaluate_concept_compatibility,
     evaluate_rasterio_compatibility,
     evaluate_xarray_compatibility,
@@ -125,12 +128,122 @@ class TestExtractXarrayMetadata:
         assert "max" not in result["coordinates"]["labels"]
 
 
+class _FakeScale:
+    def __init__(self, name: str):
+        self.name = name
+
+
+class _FakeDim:
+    def __init__(self, scale_names: list[str]):
+        self._scale_names = scale_names
+
+    def values(self):
+        return [_FakeScale(name) for name in self._scale_names]
+
+
+class _FakeDataset:
+    def __init__(self, dim_scale_names: list[list[str]]):
+        self.ndim = len(dim_scale_names)
+        self.dims = [_FakeDim(names) for names in dim_scale_names]
+
+
+class _FakeGroup:
+    def __init__(self, children):
+        self._children = children
+
+    def values(self):
+        return self._children.values()
+
+    def items(self):
+        return self._children.items()
+
+
+class TestGroupPruningHelpers:
+    """Test HDF5 group pruning helpers."""
+
+    def test_dataset_dim_scale_names(self):
+        """Test extraction of attached dimension-scale names."""
+        dataset = _FakeDataset([["/science/yCoordinates"], ["/science/xCoordinates"]])
+
+        assert _dataset_dim_scale_names(dataset) == {"yCoordinates", "xCoordinates"}
+
+    @patch("titiler.cmr.compatibility.h5py.Dataset", new=_FakeDataset)
+    def test_group_has_spatial_dims(self):
+        """Test spatial-dimension detection for a group."""
+        group = _FakeGroup(
+            {
+                "HHHH": _FakeDataset([["yCoordinates"], ["xCoordinates"]]),
+                "mask": _FakeDataset([["yCoordinates"], ["xCoordinates"]]),
+            }
+        )
+
+        assert _group_has_spatial_dims(group) is True
+
+    @patch("titiler.cmr.compatibility.h5py.Dataset", new=_FakeDataset)
+    def test_group_has_spatial_dims_false_when_aliases_missing(self):
+        """Test non-spatial groups are rejected by the dim-alias filter."""
+        group = _FakeGroup(
+            {
+                "quaternions": _FakeDataset([[], []]),
+                "time": _FakeDataset([[]]),
+            }
+        )
+
+        assert _group_has_spatial_dims(group) is False
+
+    @patch("titiler.cmr.compatibility.h5py.Group", new=_FakeGroup)
+    @patch("titiler.cmr.compatibility.h5py.Dataset", new=_FakeDataset)
+    @patch("titiler.cmr.compatibility._make_blockstore_reader")
+    @patch("titiler.cmr.compatibility.h5py.File")
+    def test_candidate_group_paths_prefers_non_metadata_spatial_groups(
+        self, mock_h5py_file, mock_reader
+    ):
+        """Test group pruning prefers non-metadata groups with spatial dims."""
+        mock_reader.return_value = MagicMock()
+
+        fake_groups = {
+            "science/LSAR/GCOV/grids/frequencyA": _FakeGroup(
+                {"HHHH": _FakeDataset([["yCoordinates"], ["xCoordinates"]])}
+            ),
+            "science/LSAR/GCOV/metadata/radarGrid": _FakeGroup(
+                {
+                    "slantRange": _FakeDataset(
+                        [["heightAboveEllipsoid"], ["yCoordinates"], ["xCoordinates"]]
+                    )
+                }
+            ),
+            "science/LSAR/GCOV/metadata/attitude": _FakeGroup(
+                {"quaternions": _FakeDataset([[], []])}
+            ),
+        }
+
+        file_handle = MagicMock()
+
+        def visititems(visitor):
+            for name, obj in fake_groups.items():
+                visitor(name, obj)
+
+        file_handle.visititems.side_effect = visititems
+        mock_h5py_file.return_value.__enter__.return_value = file_handle
+        mock_h5py_file.return_value.__exit__.return_value = False
+
+        result = _candidate_group_paths("https://example.com/file.h5")
+
+        assert result == ["science/LSAR/GCOV/grids/frequencyA"]
+
+
 class TestXarrayCompatibility:
     """Test evaluate_xarray_compatibility function."""
 
+    @patch("titiler.cmr.compatibility._group_hints")
     @patch("titiler.cmr.compatibility.open_dataset")
     @patch("titiler.cmr.compatibility.get_granules")
-    def test_xarray_success(self, mock_get_granules, mock_open_dataset):
+    def test_xarray_success(
+        self,
+        mock_get_granules,
+        mock_open_dataset,
+        mock_group_hints,
+    ):
         """Test successful xarray compatibility check."""
         request = _make_request()
         granule = _make_granule()
@@ -148,11 +261,19 @@ class TestXarrayCompatibility:
         mock_ds.coords = mock_coords
         mock_ds.dims = {"x": 10, "y": 20}
         mock_open_dataset.return_value = mock_ds
+        mock_group_hints.return_value = {
+            "requires_group": False,
+            "group_hints": [],
+            "default_group": None,
+            "sampled_group": None,
+        }
 
         result = evaluate_xarray_compatibility("C1234-TEST", request)
 
         assert result["backend"] == "xarray"
         assert result["example_assets"] == "https://example.com/file.nc"
+        assert result["requires_group"] is False
+        assert result["group_hints"] == []
         assert "temp" in result["variables"]
 
     @patch("titiler.cmr.compatibility.get_granules")
@@ -164,10 +285,14 @@ class TestXarrayCompatibility:
         with pytest.raises(ValueError, match="No assets found"):
             evaluate_xarray_compatibility("C1234-TEST", request)
 
+    @patch("titiler.cmr.compatibility._group_hints")
     @patch("titiler.cmr.compatibility.open_dataset")
     @patch("titiler.cmr.compatibility.get_granules")
     def test_xarray_uses_direct_href_when_s3_access(
-        self, mock_get_granules, mock_open_dataset
+        self,
+        mock_get_granules,
+        mock_open_dataset,
+        mock_group_hints,
     ):
         """Test that direct_href is used when s3_access is True."""
         request = _make_request(s3_access=True)
@@ -180,10 +305,62 @@ class TestXarrayCompatibility:
         mock_ds.coords.items.return_value = []
         mock_ds.dims = {}
         mock_open_dataset.return_value = mock_ds
+        mock_group_hints.return_value = {
+            "requires_group": False,
+            "group_hints": [],
+            "default_group": None,
+            "sampled_group": None,
+        }
 
         result = evaluate_xarray_compatibility("C1234-TEST", request)
 
         assert result["example_assets"] == "s3://bucket/file.nc"
+
+    @patch("titiler.cmr.compatibility._group_hints")
+    @patch("titiler.cmr.compatibility.open_dataset")
+    @patch("titiler.cmr.compatibility.get_granules")
+    def test_xarray_sets_group_hints_when_root_dataset_is_empty(
+        self,
+        mock_get_granules,
+        mock_open_dataset,
+        mock_group_hints,
+    ):
+        """Test grouped xarray compatibility metadata for hierarchical datasets."""
+        request = _make_request()
+        granule = _make_granule()
+        mock_get_granules.return_value = iter([granule])
+
+        root_ds = MagicMock()
+        root_ds.data_vars = []
+        root_ds.coords = MagicMock()
+        root_ds.coords.items.return_value = []
+        root_ds.dims = {}
+
+        grouped_ds = MagicMock()
+        grouped_var = MagicMock()
+        grouped_var.shape = (10, 20)
+        grouped_var.dtype = np.dtype("float32")
+        grouped_ds.data_vars = ["backscatter"]
+        grouped_ds.__getitem__ = lambda self, key: grouped_var
+        grouped_ds.coords = MagicMock()
+        grouped_ds.coords.items.return_value = []
+        grouped_ds.dims = {"x": 10, "y": 20}
+
+        mock_open_dataset.side_effect = [root_ds, grouped_ds]
+        mock_group_hints.return_value = {
+            "requires_group": False,
+            "group_hints": ["science/grids/frequencyA"],
+            "default_group": "science/grids/frequencyA",
+            "sampled_group": "science/grids/frequencyA",
+        }
+
+        result = evaluate_xarray_compatibility("C1234-TEST", request)
+
+        assert result["requires_group"] is True
+        assert result["group_hints"] == ["science/grids/frequencyA"]
+        assert result["default_group"] == "science/grids/frequencyA"
+        assert result["sampled_group"] == "science/grids/frequencyA"
+        assert "backscatter" in result["variables"]
 
 
 class TestRasterioCompatibility:
@@ -241,6 +418,10 @@ class TestConceptCompatibility:
             "dimensions": {"x": 10},
             "coordinates": {},
             "example_assets": "https://example.com/file.nc",
+            "requires_group": False,
+            "group_hints": [],
+            "default_group": None,
+            "sampled_group": None,
         }
 
         result = evaluate_concept_compatibility("C1234-TEST", request)
@@ -272,6 +453,10 @@ class TestConceptCompatibility:
             "dimensions": {},
             "coordinates": {},
             "example_assets": "https://example.com/file.nc",
+            "requires_group": False,
+            "group_hints": [],
+            "default_group": None,
+            "sampled_group": None,
         }
 
         result = evaluate_concept_compatibility("C1234-TEST", request)
@@ -280,6 +465,37 @@ class TestConceptCompatibility:
         assert "variable=sea_ice" in tilejson_link.href
         assert "{temporal}" in tilejson_link.href
         assert "/xarray/" in tilejson_link.href
+
+    @patch("titiler.cmr.compatibility.evaluate_rasterio_compatibility")
+    @patch("titiler.cmr.compatibility.evaluate_xarray_compatibility")
+    @patch("titiler.cmr.compatibility.get_collection")
+    def test_xarray_links_include_sampled_group(
+        self, mock_get_collection, mock_xarray, mock_rasterio
+    ):
+        """Test that xarray links include the sampled group when metadata came from it."""
+        request = _make_request()
+
+        mock_collection = MagicMock()
+        mock_collection.temporal_extents = []
+        mock_get_collection.return_value = mock_collection
+
+        mock_xarray.return_value = {
+            "backend": "xarray",
+            "variables": {"backscatter": {"shape": [10], "dtype": "float32"}},
+            "dimensions": {},
+            "coordinates": {},
+            "example_assets": "https://example.com/file.nc",
+            "requires_group": True,
+            "group_hints": ["science/grids/frequencyA"],
+            "default_group": None,
+            "sampled_group": "science/grids/frequencyA",
+        }
+
+        result = evaluate_concept_compatibility("C1234-TEST", request)
+
+        tilejson_link = next(link for link in result.links if link.rel == "tilejson")
+        assert "group=science/grids/frequencyA" in tilejson_link.href
+        mock_rasterio.assert_not_called()
 
     @patch("titiler.cmr.compatibility.evaluate_rasterio_compatibility")
     @patch("titiler.cmr.compatibility.evaluate_xarray_compatibility")
@@ -354,3 +570,34 @@ class TestCompatibilityEndpoint:
         data = response.json()
         assert data["backend"] == "xarray"
         assert data["concept_id"] == "C1234-TEST"
+        assert mock_evaluate.call_args.kwargs["group"] is None
+
+    @patch("titiler.cmr.compatibility.evaluate_concept_compatibility")
+    def test_endpoint_accepts_group(self, mock_evaluate, app):
+        """Test the /compatibility endpoint forwards the optional group parameter."""
+        mock_evaluate.return_value = CompatibilityResponse(
+            concept_id="C1234-TEST",
+            backend="xarray",
+            datetime=[],
+            sampled_group="science/grids/frequencyA",
+            links=[],
+        )
+
+        response = app.get(
+            "/compatibility?collection_concept_id=C1234-TEST&group=science/grids/frequencyA"
+        )
+
+        assert response.status_code == 200
+        assert mock_evaluate.call_args.kwargs["group"] == "science/grids/frequencyA"
+
+    def test_endpoint_openapi_documents_group_like_xarray_routes(self, app):
+        """Test the /compatibility endpoint reuses the shared xarray group parameter docs."""
+        response = app.get("/api")
+
+        assert response.status_code == 200
+        parameters = response.json()["paths"]["/compatibility"]["get"]["parameters"]
+        group_param = next(param for param in parameters if param["name"] == "group")
+        assert group_param["description"] == (
+            "Select a specific zarr group from a zarr hierarchy. "
+            "Could be associated with a zoom level or dataset."
+        )

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -235,14 +235,14 @@ class TestGroupPruningHelpers:
 class TestXarrayCompatibility:
     """Test evaluate_xarray_compatibility function."""
 
-    @patch("titiler.cmr.compatibility._group_hints")
+    @patch("titiler.cmr.compatibility._compatible_groups")
     @patch("titiler.cmr.compatibility.open_dataset")
     @patch("titiler.cmr.compatibility.get_granules")
     def test_xarray_success(
         self,
         mock_get_granules,
         mock_open_dataset,
-        mock_group_hints,
+        mock_compatible_groups,
     ):
         """Test successful xarray compatibility check."""
         request = _make_request()
@@ -261,19 +261,13 @@ class TestXarrayCompatibility:
         mock_ds.coords = mock_coords
         mock_ds.dims = {"x": 10, "y": 20}
         mock_open_dataset.return_value = mock_ds
-        mock_group_hints.return_value = {
-            "requires_group": False,
-            "group_hints": [],
-            "default_group": None,
-            "sampled_group": None,
-        }
+        mock_compatible_groups.return_value = []
 
         result = evaluate_xarray_compatibility("C1234-TEST", request)
 
         assert result["backend"] == "xarray"
         assert result["example_assets"] == "https://example.com/file.nc"
-        assert result["requires_group"] is False
-        assert result["group_hints"] == []
+        assert result.get("compatible_groups") is None
         assert "temp" in result["variables"]
 
     @patch("titiler.cmr.compatibility.get_granules")
@@ -285,14 +279,14 @@ class TestXarrayCompatibility:
         with pytest.raises(ValueError, match="No assets found"):
             evaluate_xarray_compatibility("C1234-TEST", request)
 
-    @patch("titiler.cmr.compatibility._group_hints")
+    @patch("titiler.cmr.compatibility._compatible_groups")
     @patch("titiler.cmr.compatibility.open_dataset")
     @patch("titiler.cmr.compatibility.get_granules")
     def test_xarray_uses_direct_href_when_s3_access(
         self,
         mock_get_granules,
         mock_open_dataset,
-        mock_group_hints,
+        mock_compatible_groups,
     ):
         """Test that direct_href is used when s3_access is True."""
         request = _make_request(s3_access=True)
@@ -305,27 +299,22 @@ class TestXarrayCompatibility:
         mock_ds.coords.items.return_value = []
         mock_ds.dims = {}
         mock_open_dataset.return_value = mock_ds
-        mock_group_hints.return_value = {
-            "requires_group": False,
-            "group_hints": [],
-            "default_group": None,
-            "sampled_group": None,
-        }
+        mock_compatible_groups.return_value = []
 
         result = evaluate_xarray_compatibility("C1234-TEST", request)
 
         assert result["example_assets"] == "s3://bucket/file.nc"
 
-    @patch("titiler.cmr.compatibility._group_hints")
+    @patch("titiler.cmr.compatibility._compatible_groups")
     @patch("titiler.cmr.compatibility.open_dataset")
     @patch("titiler.cmr.compatibility.get_granules")
-    def test_xarray_sets_group_hints_when_root_dataset_is_empty(
+    def test_xarray_lists_compatible_groups_when_root_dataset_is_empty(
         self,
         mock_get_granules,
         mock_open_dataset,
-        mock_group_hints,
+        mock_compatible_groups,
     ):
-        """Test grouped xarray compatibility metadata for hierarchical datasets."""
+        """Test grouped xarray compatibility returns group paths without nested inspection."""
         request = _make_request()
         granule = _make_granule()
         mock_get_granules.return_value = iter([granule])
@@ -336,31 +325,13 @@ class TestXarrayCompatibility:
         root_ds.coords.items.return_value = []
         root_ds.dims = {}
 
-        grouped_ds = MagicMock()
-        grouped_var = MagicMock()
-        grouped_var.shape = (10, 20)
-        grouped_var.dtype = np.dtype("float32")
-        grouped_ds.data_vars = ["backscatter"]
-        grouped_ds.__getitem__ = lambda self, key: grouped_var
-        grouped_ds.coords = MagicMock()
-        grouped_ds.coords.items.return_value = []
-        grouped_ds.dims = {"x": 10, "y": 20}
-
-        mock_open_dataset.side_effect = [root_ds, grouped_ds]
-        mock_group_hints.return_value = {
-            "requires_group": False,
-            "group_hints": ["science/grids/frequencyA"],
-            "default_group": "science/grids/frequencyA",
-            "sampled_group": "science/grids/frequencyA",
-        }
+        mock_open_dataset.return_value = root_ds
+        mock_compatible_groups.return_value = ["science/grids/frequencyA"]
 
         result = evaluate_xarray_compatibility("C1234-TEST", request)
 
-        assert result["requires_group"] is True
-        assert result["group_hints"] == ["science/grids/frequencyA"]
-        assert result["default_group"] == "science/grids/frequencyA"
-        assert result["sampled_group"] == "science/grids/frequencyA"
-        assert "backscatter" in result["variables"]
+        assert result["compatible_groups"] == ["science/grids/frequencyA"]
+        assert result["variables"] == {}
 
 
 class TestRasterioCompatibility:
@@ -418,10 +389,7 @@ class TestConceptCompatibility:
             "dimensions": {"x": 10},
             "coordinates": {},
             "example_assets": "https://example.com/file.nc",
-            "requires_group": False,
-            "group_hints": [],
-            "default_group": None,
-            "sampled_group": None,
+            "compatible_groups": None,
         }
 
         result = evaluate_concept_compatibility("C1234-TEST", request)
@@ -453,26 +421,23 @@ class TestConceptCompatibility:
             "dimensions": {},
             "coordinates": {},
             "example_assets": "https://example.com/file.nc",
-            "requires_group": False,
-            "group_hints": [],
-            "default_group": None,
-            "sampled_group": None,
+            "compatible_groups": None,
         }
 
         result = evaluate_concept_compatibility("C1234-TEST", request)
 
         tilejson_link = next(link for link in result.links if link.rel == "tilejson")
-        assert "variable=sea_ice" in tilejson_link.href
+        assert "variables=sea_ice" in tilejson_link.href
         assert "{temporal}" in tilejson_link.href
         assert "/xarray/" in tilejson_link.href
 
     @patch("titiler.cmr.compatibility.evaluate_rasterio_compatibility")
     @patch("titiler.cmr.compatibility.evaluate_xarray_compatibility")
     @patch("titiler.cmr.compatibility.get_collection")
-    def test_xarray_links_include_sampled_group(
+    def test_xarray_links_include_explicit_group(
         self, mock_get_collection, mock_xarray, mock_rasterio
     ):
-        """Test that xarray links include the sampled group when metadata came from it."""
+        """Test that xarray links include the explicit group parameter."""
         request = _make_request()
 
         mock_collection = MagicMock()
@@ -485,16 +450,43 @@ class TestConceptCompatibility:
             "dimensions": {},
             "coordinates": {},
             "example_assets": "https://example.com/file.nc",
-            "requires_group": True,
-            "group_hints": ["science/grids/frequencyA"],
-            "default_group": None,
-            "sampled_group": "science/grids/frequencyA",
+            "compatible_groups": None,
+        }
+
+        result = evaluate_concept_compatibility(
+            "C1234-TEST", request, group="science/grids/frequencyA"
+        )
+
+        tilejson_link = next(link for link in result.links if link.rel == "tilejson")
+        assert "group=science/grids/frequencyA" in tilejson_link.href
+        mock_rasterio.assert_not_called()
+
+    @patch("titiler.cmr.compatibility.evaluate_rasterio_compatibility")
+    @patch("titiler.cmr.compatibility.evaluate_xarray_compatibility")
+    @patch("titiler.cmr.compatibility.get_collection")
+    def test_xarray_returns_no_links_without_variable_inspection(
+        self, mock_get_collection, mock_xarray, mock_rasterio
+    ):
+        """Test grouped root responses do not fabricate xarray links."""
+        request = _make_request()
+
+        mock_collection = MagicMock()
+        mock_collection.temporal_extents = []
+        mock_get_collection.return_value = mock_collection
+
+        mock_xarray.return_value = {
+            "backend": "xarray",
+            "variables": {},
+            "dimensions": {},
+            "coordinates": {},
+            "example_assets": "https://example.com/file.nc",
+            "compatible_groups": ["science/grids/frequencyA"],
         }
 
         result = evaluate_concept_compatibility("C1234-TEST", request)
 
-        tilejson_link = next(link for link in result.links if link.rel == "tilejson")
-        assert "group=science/grids/frequencyA" in tilejson_link.href
+        assert result.backend == "xarray"
+        assert result.links == []
         mock_rasterio.assert_not_called()
 
     @patch("titiler.cmr.compatibility.evaluate_rasterio_compatibility")
@@ -579,7 +571,7 @@ class TestCompatibilityEndpoint:
             concept_id="C1234-TEST",
             backend="xarray",
             datetime=[],
-            sampled_group="science/grids/frequencyA",
+            compatible_groups=["science/grids/frequencyA"],
             links=[],
         )
 

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,9 +1,13 @@
 """Test titiler.cmr.compatibility module."""
 
-from unittest.mock import MagicMock, patch
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
+import h5py
 import numpy as np
 import pytest
+import xarray as xr
 from fastapi import HTTPException
 
 from titiler.cmr.compatibility import (
@@ -23,17 +27,53 @@ from titiler.cmr.models import (
 )
 
 
+class _PathReader:
+    def __init__(self, path: Path):
+        self._path = path
+
+    def __fspath__(self) -> str:
+        return str(self._path)
+
+    def close(self) -> None:
+        return None
+
+
+class _FakeRasterReader:
+    def __init__(self, info_result):
+        self.assets = ["0"]
+        self._info_result = info_result
+
+    def info(self, assets: list[str]):
+        assert assets == ["0"]
+        return {"0": self._info_result}
+
+
+class _FakeRasterReaderContext:
+    def __init__(self, info_result):
+        self._reader = _FakeRasterReader(info_result)
+
+    def __enter__(self) -> _FakeRasterReader:
+        return self._reader
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
 def _make_request(s3_access=False, auth_token=None, get_s3_credentials=None):
-    """Build a mock FastAPI Request with app.state fields set."""
-    request = MagicMock()
-    request.app.state.client = MagicMock()
-    request.app.state.s3_access = s3_access
-    request.app.state.earthdata_token_provider = (
-        (lambda: auth_token) if auth_token is not None else None
+    """Build a lightweight Request-like object with app.state fields set."""
+    return SimpleNamespace(
+        app=SimpleNamespace(
+            state=SimpleNamespace(
+                client=object(),
+                s3_access=s3_access,
+                earthdata_token_provider=(
+                    (lambda: auth_token) if auth_token is not None else None
+                ),
+                get_s3_credentials=get_s3_credentials,
+            )
+        ),
+        base_url="http://testserver/",
     )
-    request.app.state.get_s3_credentials = get_s3_credentials
-    request.base_url = "http://testserver/"
-    return request
 
 
 def _make_granule(external_href="https://example.com/file.nc") -> Granule:
@@ -67,165 +107,183 @@ def _make_granule(external_href="https://example.com/file.nc") -> Granule:
     )
 
 
+def _make_xarray_dataset(
+    data_vars: dict[str, tuple[tuple[str, ...], np.ndarray]],
+    coords: dict[str, np.ndarray] | None = None,
+) -> xr.Dataset:
+    """Create a small in-memory xarray dataset for tests."""
+    return xr.Dataset(
+        data_vars={name: (dims, values) for name, (dims, values) in data_vars.items()},
+        coords=coords,
+    )
+
+
+def _write_test_hdf5(path: Path) -> Path:
+    """Create a real HDF5 hierarchy with spatial and metadata groups."""
+    with h5py.File(path, "w") as file_handle:
+        grids = file_handle.create_group("science/LSAR/GCOV/grids/frequencyA")
+        metadata_grid = file_handle.create_group("science/LSAR/GCOV/metadata/radarGrid")
+        metadata_attitude = file_handle.create_group(
+            "science/LSAR/GCOV/metadata/attitude"
+        )
+
+        y = grids.create_dataset("yCoordinates", data=np.arange(2, dtype=np.float32))
+        y.make_scale("yCoordinates")
+        x = grids.create_dataset("xCoordinates", data=np.arange(3, dtype=np.float32))
+        x.make_scale("xCoordinates")
+        raster = grids.create_dataset("HHHH", data=np.zeros((2, 3), dtype=np.float32))
+        raster.dims[0].attach_scale(y)
+        raster.dims[1].attach_scale(x)
+
+        z = metadata_grid.create_dataset(
+            "heightAboveEllipsoid", data=np.arange(4, dtype=np.float32)
+        )
+        z.make_scale("heightAboveEllipsoid")
+        metadata_y = metadata_grid.create_dataset(
+            "yCoordinates", data=np.arange(2, dtype=np.float32)
+        )
+        metadata_y.make_scale("yCoordinates")
+        metadata_x = metadata_grid.create_dataset(
+            "xCoordinates", data=np.arange(3, dtype=np.float32)
+        )
+        metadata_x.make_scale("xCoordinates")
+        slant_range = metadata_grid.create_dataset(
+            "slantRange", data=np.zeros((4, 2, 3), dtype=np.float32)
+        )
+        slant_range.dims[0].attach_scale(z)
+        slant_range.dims[1].attach_scale(metadata_y)
+        slant_range.dims[2].attach_scale(metadata_x)
+
+        metadata_attitude.create_dataset(
+            "quaternions", data=np.zeros((2, 4), dtype=np.float32)
+        )
+
+    return path
+
+
+def _write_test_hdf5_with_unblessed_spatial_names(path: Path) -> Path:
+    """Create an HDF5 file whose scales look spatial but use unsupported names."""
+    with h5py.File(path, "w") as file_handle:
+        grids = file_handle.create_group("science/LSAR/GCOV/grids/frequencyA")
+
+        row = grids.create_dataset(
+            "rowCoordinates", data=np.arange(2, dtype=np.float32)
+        )
+        row.make_scale("rowCoordinates")
+        col = grids.create_dataset(
+            "columnCoordinates", data=np.arange(3, dtype=np.float32)
+        )
+        col.make_scale("columnCoordinates")
+        raster = grids.create_dataset("HHHH", data=np.zeros((2, 3), dtype=np.float32))
+        raster.dims[0].attach_scale(row)
+        raster.dims[1].attach_scale(col)
+
+    return path
+
+
 class TestExtractXarrayMetadata:
     """Test extract_xarray_metadata function."""
 
     def test_extract_basic_metadata(self):
         """Test extracting metadata from a simple dataset."""
-        mock_ds = MagicMock()
+        dataset = _make_xarray_dataset(
+            {
+                "temperature": (
+                    ("time", "lat", "lon"),
+                    np.arange(24, dtype=np.float32).reshape(3, 2, 4),
+                )
+            },
+            coords={"time": np.arange(3, dtype=np.float64)},
+        )
 
-        mock_var = MagicMock()
-        mock_var.shape = (365, 1800, 3600)
-        mock_var.dtype = np.dtype("float32")
-        mock_ds.data_vars = ["temperature"]
-        mock_ds.__getitem__ = lambda self, key: mock_var
-
-        mock_coord = MagicMock()
-        mock_coord.size = 365
-        mock_coord.dtype = np.dtype("float64")
-        mock_coord.min.return_value = 0.0
-        mock_coord.max.return_value = 364.0
-
-        mock_coords = MagicMock()
-        mock_coords.__getitem__ = lambda self, key: mock_coord
-        mock_coords.items.return_value = [("time", mock_coord)]
-        mock_ds.coords = mock_coords
-        mock_ds.dims = {"time": 365, "lat": 1800, "lon": 3600}
-
-        result = extract_xarray_metadata(mock_ds)
+        result = extract_xarray_metadata(dataset)
 
         assert result["backend"] == "xarray"
         assert "temperature" in result["variables"]
-        assert result["variables"]["temperature"]["shape"] == [365, 1800, 3600]
+        assert result["variables"]["temperature"]["shape"] == [3, 2, 4]
         assert result["variables"]["temperature"]["dtype"] == "float32"
-        assert result["dimensions"] == {"time": 365, "lat": 1800, "lon": 3600}
+        assert result["dimensions"] == {"time": 3, "lat": 2, "lon": 4}
         assert "time" in result["coordinates"]
-        assert result["coordinates"]["time"]["size"] == 365
+        assert result["coordinates"]["time"]["size"] == 3
 
     def test_extract_metadata_with_non_numeric_coord(self):
         """Test extracting metadata with non-numeric coordinate."""
-        mock_ds = MagicMock()
+        dataset = _make_xarray_dataset(
+            {"data": (("labels",), np.arange(10, dtype=np.float32))},
+            coords={"labels": np.array([f"label-{i}" for i in range(10)])},
+        )
 
-        mock_var = MagicMock()
-        mock_var.shape = (10,)
-        mock_var.dtype = np.dtype("float32")
-        mock_ds.data_vars = ["data"]
-        mock_ds.__getitem__ = lambda self, key: mock_var
-
-        mock_coord = MagicMock()
-        mock_coord.size = 10
-        mock_coord.dtype = np.dtype("U10")  # Unicode string
-
-        mock_coords = MagicMock()
-        mock_coords.__getitem__ = lambda self, key: mock_coord
-        mock_coords.items.return_value = [("labels", mock_coord)]
-        mock_ds.coords = mock_coords
-        mock_ds.dims = {"labels": 10}
-
-        result = extract_xarray_metadata(mock_ds)
+        result = extract_xarray_metadata(dataset)
 
         assert "min" not in result["coordinates"]["labels"]
         assert "max" not in result["coordinates"]["labels"]
 
 
-class _FakeScale:
-    def __init__(self, name: str):
-        self.name = name
-
-
-class _FakeDim:
-    def __init__(self, scale_names: list[str]):
-        self._scale_names = scale_names
-
-    def values(self):
-        return [_FakeScale(name) for name in self._scale_names]
-
-
-class _FakeDataset:
-    def __init__(self, dim_scale_names: list[list[str]]):
-        self.ndim = len(dim_scale_names)
-        self.dims = [_FakeDim(names) for names in dim_scale_names]
-
-
-class _FakeGroup:
-    def __init__(self, children):
-        self._children = children
-
-    def values(self):
-        return self._children.values()
-
-    def items(self):
-        return self._children.items()
-
-
 class TestGroupPruningHelpers:
     """Test HDF5 group pruning helpers."""
 
-    def test_dataset_dim_scale_names(self):
+    def test_dataset_dim_scale_names(self, tmp_path: Path):
         """Test extraction of attached dimension-scale names."""
-        dataset = _FakeDataset([["/science/yCoordinates"], ["/science/xCoordinates"]])
+        hdf5_path = _write_test_hdf5(tmp_path / "scales.h5")
 
-        assert _dataset_dim_scale_names(dataset) == {"yCoordinates", "xCoordinates"}
+        with h5py.File(hdf5_path, "r") as file_handle:
+            dataset = file_handle["science/LSAR/GCOV/grids/frequencyA/HHHH"]
+            assert _dataset_dim_scale_names(dataset) == {"yCoordinates", "xCoordinates"}
 
-    @patch("titiler.cmr.compatibility.h5py.Dataset", new=_FakeDataset)
-    def test_group_has_spatial_dims(self):
+    def test_group_has_spatial_dims(self, tmp_path: Path):
         """Test spatial-dimension detection for a group."""
-        group = _FakeGroup(
-            {
-                "HHHH": _FakeDataset([["yCoordinates"], ["xCoordinates"]]),
-                "mask": _FakeDataset([["yCoordinates"], ["xCoordinates"]]),
-            }
-        )
+        hdf5_path = _write_test_hdf5(tmp_path / "spatial.h5")
 
-        assert _group_has_spatial_dims(group) is True
+        with h5py.File(hdf5_path, "r") as file_handle:
+            group = file_handle["science/LSAR/GCOV/grids/frequencyA"]
+            assert _group_has_spatial_dims(group) is True
 
-    @patch("titiler.cmr.compatibility.h5py.Dataset", new=_FakeDataset)
-    def test_group_has_spatial_dims_false_when_aliases_missing(self):
+    def test_group_has_spatial_dims_false_when_aliases_missing(self, tmp_path: Path):
         """Test non-spatial groups are rejected by the dim-alias filter."""
-        group = _FakeGroup(
-            {
-                "quaternions": _FakeDataset([[], []]),
-                "time": _FakeDataset([[]]),
-            }
+        hdf5_path = _write_test_hdf5(tmp_path / "non-spatial.h5")
+
+        with h5py.File(hdf5_path, "r") as file_handle:
+            group = file_handle["science/LSAR/GCOV/metadata/attitude"]
+            assert _group_has_spatial_dims(group) is False
+
+    def test_group_has_spatial_dims_false_for_unblessed_spatial_names(
+        self, tmp_path: Path
+    ):
+        """Test spatial-looking scale names are ignored unless they are blessed aliases."""
+        hdf5_path = _write_test_hdf5_with_unblessed_spatial_names(
+            tmp_path / "unblessed-spatial.h5"
         )
 
-        assert _group_has_spatial_dims(group) is False
+        with h5py.File(hdf5_path, "r") as file_handle:
+            group = file_handle["science/LSAR/GCOV/grids/frequencyA"]
+            assert _group_has_spatial_dims(group) is False
+            dataset = file_handle["science/LSAR/GCOV/grids/frequencyA/HHHH"]
+            assert _dataset_dim_scale_names(dataset) == {
+                "rowCoordinates",
+                "columnCoordinates",
+            }
 
-    @patch("titiler.cmr.compatibility.h5py.Group", new=_FakeGroup)
-    @patch("titiler.cmr.compatibility.h5py.Dataset", new=_FakeDataset)
     @patch("titiler.cmr.compatibility._make_blockstore_reader")
-    @patch("titiler.cmr.compatibility.h5py.File")
+    def test_candidate_group_paths_falls_back_to_all_groups_when_aliases_are_unblessed(
+        self, mock_reader, tmp_path: Path
+    ):
+        """Test group discovery falls back when no group's scale names match blessed aliases."""
+        hdf5_path = _write_test_hdf5_with_unblessed_spatial_names(
+            tmp_path / "unblessed-groups.h5"
+        )
+        mock_reader.return_value = _PathReader(hdf5_path)
+
+        result = _candidate_group_paths("https://example.com/file.h5")
+
+        assert result == ["science/LSAR/GCOV/grids/frequencyA"]
+
+    @patch("titiler.cmr.compatibility._make_blockstore_reader")
     def test_candidate_group_paths_prefers_non_metadata_spatial_groups(
-        self, mock_h5py_file, mock_reader
+        self, mock_reader, tmp_path: Path
     ):
         """Test group pruning prefers non-metadata groups with spatial dims."""
-        mock_reader.return_value = MagicMock()
-
-        fake_groups = {
-            "science/LSAR/GCOV/grids/frequencyA": _FakeGroup(
-                {"HHHH": _FakeDataset([["yCoordinates"], ["xCoordinates"]])}
-            ),
-            "science/LSAR/GCOV/metadata/radarGrid": _FakeGroup(
-                {
-                    "slantRange": _FakeDataset(
-                        [["heightAboveEllipsoid"], ["yCoordinates"], ["xCoordinates"]]
-                    )
-                }
-            ),
-            "science/LSAR/GCOV/metadata/attitude": _FakeGroup(
-                {"quaternions": _FakeDataset([[], []])}
-            ),
-        }
-
-        file_handle = MagicMock()
-
-        def visititems(visitor):
-            for name, obj in fake_groups.items():
-                visitor(name, obj)
-
-        file_handle.visititems.side_effect = visititems
-        mock_h5py_file.return_value.__enter__.return_value = file_handle
-        mock_h5py_file.return_value.__exit__.return_value = False
+        hdf5_path = _write_test_hdf5(tmp_path / "groups.h5")
+        mock_reader.return_value = _PathReader(hdf5_path)
 
         result = _candidate_group_paths("https://example.com/file.h5")
 
@@ -248,19 +306,9 @@ class TestXarrayCompatibility:
         request = _make_request()
         granule = _make_granule()
         mock_get_granules.return_value = iter([granule])
-
-        mock_ds = MagicMock()
-        mock_var = MagicMock()
-        mock_var.shape = (10, 20)
-        mock_var.dtype = np.dtype("float32")
-        mock_ds.data_vars = ["temp"]
-        mock_ds.__getitem__ = lambda self, key: mock_var
-
-        mock_coords = MagicMock()
-        mock_coords.items.return_value = []
-        mock_ds.coords = mock_coords
-        mock_ds.dims = {"x": 10, "y": 20}
-        mock_open_dataset.return_value = mock_ds
+        mock_open_dataset.return_value = _make_xarray_dataset(
+            {"temp": (("x", "y"), np.arange(200, dtype=np.float32).reshape(10, 20))}
+        )
         mock_compatible_groups.return_value = []
 
         result = evaluate_xarray_compatibility("C1234-TEST", request)
@@ -292,13 +340,7 @@ class TestXarrayCompatibility:
         request = _make_request(s3_access=True)
         granule = _make_granule()
         mock_get_granules.return_value = iter([granule])
-
-        mock_ds = MagicMock()
-        mock_ds.data_vars = []
-        mock_ds.coords = MagicMock()
-        mock_ds.coords.items.return_value = []
-        mock_ds.dims = {}
-        mock_open_dataset.return_value = mock_ds
+        mock_open_dataset.return_value = _make_xarray_dataset({})
         mock_compatible_groups.return_value = []
 
         result = evaluate_xarray_compatibility("C1234-TEST", request)
@@ -318,14 +360,7 @@ class TestXarrayCompatibility:
         request = _make_request()
         granule = _make_granule()
         mock_get_granules.return_value = iter([granule])
-
-        root_ds = MagicMock()
-        root_ds.data_vars = []
-        root_ds.coords = MagicMock()
-        root_ds.coords.items.return_value = []
-        root_ds.dims = {}
-
-        mock_open_dataset.return_value = root_ds
+        mock_open_dataset.return_value = _make_xarray_dataset({})
         mock_compatible_groups.return_value = ["science/grids/frequencyA"]
 
         result = evaluate_xarray_compatibility("C1234-TEST", request)
@@ -345,19 +380,14 @@ class TestRasterioCompatibility:
         granule = _make_granule(external_href="https://example.com/file.tif")
         mock_get_granules.return_value = iter([granule])
 
-        mock_info = MagicMock()
-        mock_reader = MagicMock()
-        mock_reader.assets = ["0"]
-        mock_reader.info.return_value = {"0": mock_info}
-
-        mock_reader_cls.return_value.__enter__ = MagicMock(return_value=mock_reader)
-        mock_reader_cls.return_value.__exit__ = MagicMock(return_value=False)
+        info_result = object()
+        mock_reader_cls.return_value = _FakeRasterReaderContext(info_result)
 
         result = evaluate_rasterio_compatibility("C1234-TEST", request)
 
         assert result["backend"] == "rasterio"
         assert isinstance(result["example_assets"], dict)
-        assert result["sample_asset_raster_info"] is mock_info
+        assert result["sample_asset_raster_info"] is info_result
 
     @patch("titiler.cmr.compatibility.get_granules")
     def test_rasterio_no_assets(self, mock_get_granules):
@@ -379,10 +409,9 @@ class TestConceptCompatibility:
         """Test when xarray compatibility succeeds."""
         request = _make_request()
 
-        mock_collection = MagicMock()
-        mock_collection.temporal_extents = [{"RangeDateTimes": []}]
-        mock_get_collection.return_value = mock_collection
-
+        mock_get_collection.return_value = SimpleNamespace(
+            temporal_extents=[{"RangeDateTimes": []}]
+        )
         mock_xarray.return_value = {
             "backend": "xarray",
             "variables": {"temp": {"shape": [10], "dtype": "float32"}},
@@ -411,10 +440,7 @@ class TestConceptCompatibility:
         """Test that xarray links include the first variable name."""
         request = _make_request()
 
-        mock_collection = MagicMock()
-        mock_collection.temporal_extents = []
-        mock_get_collection.return_value = mock_collection
-
+        mock_get_collection.return_value = SimpleNamespace(temporal_extents=[])
         mock_xarray.return_value = {
             "backend": "xarray",
             "variables": {"sea_ice": {"shape": [10], "dtype": "float32"}},
@@ -440,10 +466,7 @@ class TestConceptCompatibility:
         """Test that xarray links include the explicit group parameter."""
         request = _make_request()
 
-        mock_collection = MagicMock()
-        mock_collection.temporal_extents = []
-        mock_get_collection.return_value = mock_collection
-
+        mock_get_collection.return_value = SimpleNamespace(temporal_extents=[])
         mock_xarray.return_value = {
             "backend": "xarray",
             "variables": {"backscatter": {"shape": [10], "dtype": "float32"}},
@@ -470,10 +493,7 @@ class TestConceptCompatibility:
         """Test grouped root responses do not fabricate xarray links."""
         request = _make_request()
 
-        mock_collection = MagicMock()
-        mock_collection.temporal_extents = []
-        mock_get_collection.return_value = mock_collection
-
+        mock_get_collection.return_value = SimpleNamespace(temporal_extents=[])
         mock_xarray.return_value = {
             "backend": "xarray",
             "variables": {},
@@ -498,10 +518,7 @@ class TestConceptCompatibility:
         """Test fallback to rasterio when xarray fails."""
         request = _make_request()
 
-        mock_collection = MagicMock()
-        mock_collection.temporal_extents = []
-        mock_get_collection.return_value = mock_collection
-
+        mock_get_collection.return_value = SimpleNamespace(temporal_extents=[])
         mock_xarray.side_effect = ValueError("No assets found")
         mock_rasterio.return_value = {
             "backend": "rasterio",
@@ -525,10 +542,7 @@ class TestConceptCompatibility:
         """Test when both readers fail."""
         request = _make_request()
 
-        mock_collection = MagicMock()
-        mock_collection.temporal_extents = []
-        mock_get_collection.return_value = mock_collection
-
+        mock_get_collection.return_value = SimpleNamespace(temporal_extents=[])
         mock_xarray.side_effect = ValueError("Xarray failed")
         mock_rasterio.side_effect = OSError("Rasterio failed")
 

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -31,6 +31,12 @@ class _PathReader:
     def __init__(self, path: Path):
         self._path = path
 
+    def __enter__(self) -> "_PathReader":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
     def __fspath__(self) -> str:
         return str(self._path)
 
@@ -107,17 +113,6 @@ def _make_granule(external_href="https://example.com/file.nc") -> Granule:
     )
 
 
-def _make_xarray_dataset(
-    data_vars: dict[str, tuple[tuple[str, ...], np.ndarray]],
-    coords: dict[str, np.ndarray] | None = None,
-) -> xr.Dataset:
-    """Create a small in-memory xarray dataset for tests."""
-    return xr.Dataset(
-        data_vars={name: (dims, values) for name, (dims, values) in data_vars.items()},
-        coords=coords,
-    )
-
-
 def _write_test_hdf5(path: Path) -> Path:
     """Create a real HDF5 hierarchy with spatial and metadata groups."""
     with h5py.File(path, "w") as file_handle:
@@ -186,7 +181,7 @@ class TestExtractXarrayMetadata:
 
     def test_extract_basic_metadata(self):
         """Test extracting metadata from a simple dataset."""
-        dataset = _make_xarray_dataset(
+        dataset = xr.Dataset(
             {
                 "temperature": (
                     ("time", "lat", "lon"),
@@ -208,7 +203,7 @@ class TestExtractXarrayMetadata:
 
     def test_extract_metadata_with_non_numeric_coord(self):
         """Test extracting metadata with non-numeric coordinate."""
-        dataset = _make_xarray_dataset(
+        dataset = xr.Dataset(
             {"data": (("labels",), np.arange(10, dtype=np.float32))},
             coords={"labels": np.array([f"label-{i}" for i in range(10)])},
         )
@@ -306,7 +301,7 @@ class TestXarrayCompatibility:
         request = _make_request()
         granule = _make_granule()
         mock_get_granules.return_value = iter([granule])
-        mock_open_dataset.return_value = _make_xarray_dataset(
+        mock_open_dataset.return_value = xr.Dataset(
             {"temp": (("x", "y"), np.arange(200, dtype=np.float32).reshape(10, 20))}
         )
         mock_compatible_groups.return_value = []
@@ -340,7 +335,7 @@ class TestXarrayCompatibility:
         request = _make_request(s3_access=True)
         granule = _make_granule()
         mock_get_granules.return_value = iter([granule])
-        mock_open_dataset.return_value = _make_xarray_dataset({})
+        mock_open_dataset.return_value = xr.Dataset()
         mock_compatible_groups.return_value = []
 
         result = evaluate_xarray_compatibility("C1234-TEST", request)
@@ -360,7 +355,7 @@ class TestXarrayCompatibility:
         request = _make_request()
         granule = _make_granule()
         mock_get_granules.return_value = iter([granule])
-        mock_open_dataset.return_value = _make_xarray_dataset({})
+        mock_open_dataset.return_value = xr.Dataset()
         mock_compatible_groups.return_value = ["science/grids/frequencyA"]
 
         result = evaluate_xarray_compatibility("C1234-TEST", request)

--- a/titiler/cmr/compatibility.py
+++ b/titiler/cmr/compatibility.py
@@ -1,7 +1,7 @@
 """titiler.cmr.compatibility: Compatibility testing utilities."""
 
 import urllib.parse
-from typing import Any, Dict, List, Literal, Optional, TypeAlias, cast
+from typing import Any, Literal, TypeAlias, cast
 
 import h5py
 import numpy as np
@@ -26,26 +26,26 @@ from titiler.cmr.reader import (
 
 
 class VariableInfo(BaseModel):
-    """Metadata for a single xarray variable"""
+    """Metadata for a single xarray variable."""
 
-    shape: List[int]
+    shape: list[int]
     dtype: str
-    min: Optional[float] = None
-    max: Optional[float] = None
-    mean: Optional[float] = None
-    p01: Optional[float] = None
-    p05: Optional[float] = None
-    p95: Optional[float] = None
-    p99: Optional[float] = None
+    min: float | None = None
+    max: float | None = None
+    mean: float | None = None
+    p01: float | None = None
+    p05: float | None = None
+    p95: float | None = None
+    p99: float | None = None
 
 
 class CoordinateInfo(BaseModel):
-    """Metadata for a single xarray coordinate"""
+    """Metadata for a single xarray coordinate."""
 
     size: int
     dtype: str
-    min: Optional[float] = None
-    max: Optional[float] = None
+    min: float | None = None
+    max: float | None = None
 
 
 class TemplateLink(BaseModel):
@@ -53,28 +53,28 @@ class TemplateLink(BaseModel):
 
     rel: str
     href: str
-    title: Optional[str] = None
-    type: Optional[str] = None
+    title: str | None = None
+    type: str | None = None
 
 
 class CompatibilityResponse(BaseModel):
-    """Compatibility endpoint response model"""
+    """Compatibility endpoint response model."""
 
     concept_id: str
     backend: Literal["rasterio", "xarray"]
-    datetime: List[Dict[str, Any]]
-    variables: Optional[Dict[str, VariableInfo]] = None
-    dimensions: Optional[Dict[str, int]] = None
-    coordinates: Optional[Dict[str, CoordinateInfo]] = None
-    compatible_groups: Optional[List[str]] = None
-    example_assets: Optional[Dict[str, str] | str] = None
-    sample_asset_raster_info: Optional[Info] = None
-    links: Optional[List[TemplateLink]] = None
+    datetime: list[dict[str, Any]]
+    variables: dict[str, VariableInfo] | None = None
+    dimensions: dict[str, int] | None = None
+    coordinates: dict[str, CoordinateInfo] | None = None
+    compatible_groups: list[str] | None = None
+    example_assets: dict[str, str] | str | None = None
+    sample_asset_raster_info: Info | None = None
+    links: list[TemplateLink] | None = None
 
 
 def extract_xarray_metadata(
     ds: Any, max_sample_size: float = 100_000.0
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Extract comprehensive metadata from an xarray Dataset.
 
     For large arrays, uses sampling along each dimension to avoid memory issues.
@@ -89,12 +89,12 @@ def extract_xarray_metadata(
     """
     variables = {}
     for var in ds.data_vars:
-        var_info: Dict[str, Any] = {
+        var_info: dict[str, Any] = {
             "shape": list(ds[var].shape),
             "dtype": str(ds[var].dtype),
         }
 
-        if ds[var].dtype.kind in ["i", "f", "u"]:
+        if ds[var].dtype.kind in {"i", "f", "u"}:
             try:
                 var_data = ds[var]
                 total_size = var_data.size
@@ -158,7 +158,7 @@ def extract_xarray_metadata(
             "dtype": str(coord_data.dtype),
         }
 
-        if coord_data.dtype.kind in ["i", "f", "u"]:
+        if coord_data.dtype.kind in {"i", "f", "u"}:
             try:
                 coord_info["min"] = float(coord_data.min())
                 coord_info["max"] = float(coord_data.max())
@@ -239,17 +239,18 @@ def _dataset_dim_scale_names(dataset: Any) -> set[str]:
     return dim_names
 
 
+X_DIM_ALIASES = set(X_DIM_NAMES)
+Y_DIM_ALIASES = set(Y_DIM_NAMES)
+
+
 def _group_has_spatial_dims(group: Any) -> bool:
     """Return True when a group contains a dataset with both x and y dimension aliases."""
-    x_names = set(X_DIM_NAMES)
-    y_names = set(Y_DIM_NAMES)
-
     for child in group.values():
         if not isinstance(child, h5py.Dataset):
             continue
 
         dim_names = _dataset_dim_scale_names(child)
-        if dim_names & x_names and dim_names & y_names:
+        if dim_names & X_DIM_ALIASES and dim_names & Y_DIM_ALIASES:
             return True
 
     return False
@@ -322,11 +323,30 @@ def _compatible_groups(
         return []
 
 
+def _sample_granule(concept_id: str, request: Request) -> Any:
+    """Return the first granule for a collection concept."""
+    return next(
+        get_granules(
+            search_params=GranuleSearch(collection_concept_id=concept_id),
+            client=request.app.state.client,
+            page_size=1,
+            limit=1,
+        ),
+        None,
+    )
+
+
+def _get_auth_token(request: Request) -> str | None:
+    """Return an Earthdata auth token when configured."""
+    token_provider = getattr(request.app.state, "earthdata_token_provider", None)
+    return token_provider() if token_provider else None
+
+
 def evaluate_xarray_compatibility(
     concept_id: str,
     request: Request,
     group: str | None = None,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Test XarrayReader compatibility with a concept.
 
     Args:
@@ -344,20 +364,9 @@ def evaluate_xarray_compatibility(
     """
     logger.info("Testing XarrayReader")
 
-    client = request.app.state.client
     s3_access = request.app.state.s3_access
-    token_provider = getattr(request.app.state, "earthdata_token_provider", None)
-    auth_token = token_provider() if token_provider else None
-
-    granule = next(
-        get_granules(
-            search_params=GranuleSearch(collection_concept_id=concept_id),
-            client=client,
-            page_size=1,
-            limit=1,
-        ),
-        None,
-    )
+    auth_token = _get_auth_token(request)
+    granule = _sample_granule(concept_id, request)
 
     if granule is None:
         raise ValueError("No assets found for XarrayReader")
@@ -390,7 +399,7 @@ def evaluate_xarray_compatibility(
 def evaluate_rasterio_compatibility(
     concept_id: str,
     request: Request,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Test MultiBaseGranuleReader compatibility with a concept.
 
     Args:
@@ -408,21 +417,10 @@ def evaluate_rasterio_compatibility(
     """
     logger.info("Testing MultiBaseGranuleReader")
 
-    client = request.app.state.client
     s3_access = request.app.state.s3_access
-    token_provider = getattr(request.app.state, "earthdata_token_provider", None)
-    auth_token = token_provider() if token_provider else None
+    auth_token = _get_auth_token(request)
     get_s3_credentials = request.app.state.get_s3_credentials
-
-    granule = next(
-        get_granules(
-            search_params=GranuleSearch(collection_concept_id=concept_id),
-            client=client,
-            page_size=1,
-            limit=1,
-        ),
-        None,
-    )
+    granule = _sample_granule(concept_id, request)
 
     if granule is None:
         raise ValueError("No assets found for MultiBaseGranuleReader")
@@ -452,9 +450,9 @@ def _build_links(
     base_url: str,
     concept_id: str,
     backend: str,
-    first_var: Optional[str] = None,
-    group: Optional[str] = None,
-) -> List[TemplateLink]:
+    first_var: str | None = None,
+    group: str | None = None,
+) -> list[TemplateLink]:
     """Build template links for the compatibility response."""
     if backend == "xarray":
         if not first_var:
@@ -570,9 +568,9 @@ def evaluate_concept_compatibility(
 
 
 def _concept_id_param(
-    collection_concept_id: Optional[str] = None,
-    concept_id: Optional[str] = Query(default=None, include_in_schema=False),
-) -> Optional[str]:
+    collection_concept_id: str | None = None,
+    concept_id: str | None = Query(default=None, include_in_schema=False),
+) -> str | None:
     """Accept both collection_concept_id and legacy concept_id."""
     return collection_concept_id or concept_id
 
@@ -586,7 +584,7 @@ router = APIRouter()
 @router.get("/compatibility", response_model=CompatibilityResponse)
 def compatibility_check(
     request: Request,
-    concept_id: Optional[str] = Depends(_concept_id_param),
+    concept_id: str | None = Depends(_concept_id_param),
     group: XarrayGroupParam = None,
 ) -> CompatibilityResponse:
     """Check which backend is compatible with a CMR collection concept."""

--- a/titiler/cmr/compatibility.py
+++ b/titiler/cmr/compatibility.py
@@ -504,7 +504,7 @@ def _build_links(
     """Build template links for the compatibility response."""
     if backend == "xarray" and first_var:
         prefix = "/xarray"
-        extra_params = f"&variable={first_var}"
+        extra_params = f"&variables={first_var}"
         if group:
             quoted_group = urllib.parse.quote(group, safe="/")
             extra_params = f"{extra_params}&group={quoted_group}"

--- a/titiler/cmr/compatibility.py
+++ b/titiler/cmr/compatibility.py
@@ -1,18 +1,28 @@
 """titiler.cmr.compatibility: Compatibility testing utilities."""
 
-from typing import Any, Dict, List, Literal, Optional
+import urllib.parse
+from typing import Any, Dict, List, Literal, Optional, TypeAlias, cast
 
+import h5py
 import numpy as np
 from fastapi import APIRouter, Depends, HTTPException, Query
+from obspec_utils.readers import BlockStoreReader
+from obstore import store
 from pydantic import BaseModel
 from rio_tiler.models import Info
 from starlette.requests import Request
+from titiler.xarray.dependencies import XarrayIOParams
 
 from titiler.cmr.errors import S3CredentialsEndpointMissing
 from titiler.cmr.logger import logger
 from titiler.cmr.models import GranuleSearch
 from titiler.cmr.query import get_collection, get_granules
-from titiler.cmr.reader import MultiBaseGranuleReader, open_dataset
+from titiler.cmr.reader import (
+    X_DIM_NAMES,
+    Y_DIM_NAMES,
+    MultiBaseGranuleReader,
+    open_dataset,
+)
 
 
 class VariableInfo(BaseModel):
@@ -58,6 +68,10 @@ class CompatibilityResponse(BaseModel):
     coordinates: Optional[Dict[str, CoordinateInfo]] = None
     example_assets: Optional[Dict[str, str] | str] = None
     sample_asset_raster_info: Optional[Info] = None
+    requires_group: Optional[bool] = None
+    group_hints: Optional[List[str]] = None
+    default_group: Optional[str] = None
+    sampled_group: Optional[str] = None
     links: Optional[List[TemplateLink]] = None
 
 
@@ -163,9 +177,187 @@ def extract_xarray_metadata(
     }
 
 
+def _get_credential_provider(granule: Any, request: Request) -> Any:
+    """Return a credential provider for a granule when direct S3 access is enabled."""
+    if not request.app.state.s3_access:
+        return None
+
+    get_s3_credentials = request.app.state.get_s3_credentials
+    if get_s3_credentials is None:
+        return None
+
+    try:
+        return get_s3_credentials(granule.s3_credentials_endpoint)
+    except S3CredentialsEndpointMissing:
+        logger.warning(
+            "No S3 credentials endpoint found for granule %s; falling back to token auth",
+            granule.id,
+        )
+        return None
+
+
+def _make_blockstore_reader(
+    src_path: str,
+    auth_token: str | None = None,
+    credential_provider: Any = None,
+) -> BlockStoreReader:
+    """Create a block-based reader for a remote NetCDF/HDF5 asset."""
+
+    parsed = urllib.parse.urlparse(src_path)
+    store_root = f"{parsed.scheme}://{parsed.netloc}"
+
+    if credential_provider is not None:
+        object_store = store.from_url(
+            store_root,
+            credential_provider=credential_provider,
+        )
+    elif auth_token:
+        object_store = store.from_url(
+            store_root,
+            client_options={
+                "default_headers": {"Authorization": f"Bearer {auth_token}"}
+            },
+        )
+    else:
+        object_store = store.from_url(store_root)
+
+    return BlockStoreReader(object_store, parsed.path, block_size=8 * 1024**2)
+
+
+def _dataset_dim_scale_names(dataset: Any) -> set[str]:
+    """Return all attached HDF5 dimension-scale names for a dataset."""
+    dim_names: set[str] = set()
+
+    for axis in range(dataset.ndim):
+        try:
+            scales = dataset.dims[axis].values()
+        except Exception:
+            continue
+
+        for scale in scales:
+            scale_name = getattr(scale, "name", "")
+            if scale_name:
+                dim_names.add(scale_name.rsplit("/", 1)[-1])
+
+    return dim_names
+
+
+def _group_has_spatial_dims(group: Any) -> bool:
+    """Return True when a group contains a dataset with both x and y dimension aliases."""
+    x_names = set(X_DIM_NAMES)
+    y_names = set(Y_DIM_NAMES)
+
+    for child in group.values():
+        if not isinstance(child, h5py.Dataset):
+            continue
+
+        dim_names = _dataset_dim_scale_names(child)
+        if dim_names & x_names and dim_names & y_names:
+            return True
+
+    return False
+
+
+def _candidate_group_paths(
+    src_path: str,
+    auth_token: str | None = None,
+    credential_provider: Any = None,
+) -> list[str]:
+    """Return likely xarray group paths, preferring spatial non-metadata groups."""
+    reader = _make_blockstore_reader(
+        src_path,
+        auth_token=auth_token,
+        credential_provider=credential_provider,
+    )
+    try:
+        with h5py.File(reader, "r") as file_handle:
+            all_group_paths: list[str] = []
+            spatial_group_paths: list[str] = []
+            spatial_metadata_group_paths: list[str] = []
+
+            def visitor(name: str, obj: Any) -> None:
+                if not name or not isinstance(obj, h5py.Group):
+                    return
+
+                if not any(isinstance(child, h5py.Dataset) for child in obj.values()):
+                    return
+
+                all_group_paths.append(name)
+
+                if not _group_has_spatial_dims(obj):
+                    return
+
+                normalized_name = f"/{name.strip('/')}/"
+                if "/metadata/" in normalized_name:
+                    spatial_metadata_group_paths.append(name)
+                else:
+                    spatial_group_paths.append(name)
+
+            file_handle.visititems(visitor)
+
+            if spatial_group_paths:
+                return spatial_group_paths
+            if spatial_metadata_group_paths:
+                return spatial_metadata_group_paths
+            return all_group_paths
+    finally:
+        reader.close()
+
+
+def _group_hints(
+    src_path: str,
+    auth_token: str | None = None,
+    credential_provider: Any = None,
+) -> dict[str, Any]:
+    """Inspect a hierarchical asset and return lightweight xarray group hints."""
+    try:
+        group_paths = _candidate_group_paths(
+            src_path,
+            auth_token=auth_token,
+            credential_provider=credential_provider,
+        )
+    except Exception as exc:
+        logger.info("Skipping group inspection for %s: %s", src_path, exc)
+        return {
+            "requires_group": False,
+            "group_hints": [],
+            "default_group": None,
+            "sampled_group": None,
+        }
+
+    group_hints: list[str] = []
+    for group_path in group_paths:
+        try:
+            grouped_dataset = open_dataset(
+                src_path,
+                group=group_path,
+                credential_provider=credential_provider,
+                auth_token=auth_token,
+            )
+        except Exception as exc:
+            logger.info(
+                "Skipping incompatible group %s for %s: %s",
+                group_path,
+                src_path,
+                exc,
+            )
+            continue
+
+        if grouped_dataset.data_vars:
+            group_hints.append(group_path)
+
+    return {
+        "requires_group": False,
+        "group_hints": group_hints,
+        "default_group": group_hints[0] if len(group_hints) == 1 else None,
+        "sampled_group": group_hints[0] if group_hints else None,
+    }
+
+
 def evaluate_xarray_compatibility(
     concept_id: str,
     request: Request,
+    group: str | None = None,
 ) -> Dict[str, Any]:
     """Test XarrayReader compatibility with a concept.
 
@@ -188,7 +380,6 @@ def evaluate_xarray_compatibility(
     s3_access = request.app.state.s3_access
     token_provider = getattr(request.app.state, "earthdata_token_provider", None)
     auth_token = token_provider() if token_provider else None
-    get_s3_credentials = request.app.state.get_s3_credentials
 
     granule = next(
         get_granules(
@@ -207,23 +398,37 @@ def evaluate_xarray_compatibility(
     asset = assets["0"]
     href = asset.direct_href if s3_access else asset.external_href
 
-    credential_provider = None
-    if s3_access and get_s3_credentials is not None:
-        try:
-            credential_provider = get_s3_credentials(granule.s3_credentials_endpoint)
-        except S3CredentialsEndpointMissing:
-            logger.warning(
-                "No S3 credentials endpoint found for granule %s; "
-                "falling back to token auth",
-                granule.id,
-            )
+    credential_provider = _get_credential_provider(granule, request)
 
     ds = open_dataset(
         href,
+        group=group,
         credential_provider=credential_provider,
         auth_token=auth_token,
     )
     result = extract_xarray_metadata(ds)
+    group_hints = _group_hints(
+        href,
+        auth_token=auth_token,
+        credential_provider=credential_provider,
+    )
+
+    sampled_group = group if group else group_hints.get("sampled_group")
+    if not group and not result["variables"] and sampled_group:
+        sampled_ds = open_dataset(
+            href,
+            group=sampled_group,
+            credential_provider=credential_provider,
+            auth_token=auth_token,
+        )
+        result = extract_xarray_metadata(sampled_ds)
+
+    group_hints["requires_group"] = (
+        bool(group_hints["group_hints"]) and not bool(group) and not bool(ds.data_vars)
+    )
+    group_hints["sampled_group"] = sampled_group
+
+    result.update(group_hints)
     result["example_assets"] = href
     return result
 
@@ -294,11 +499,15 @@ def _build_links(
     concept_id: str,
     backend: str,
     first_var: Optional[str] = None,
+    group: Optional[str] = None,
 ) -> List[TemplateLink]:
     """Build template links for the compatibility response."""
     if backend == "xarray" and first_var:
         prefix = "/xarray"
         extra_params = f"&variable={first_var}"
+        if group:
+            quoted_group = urllib.parse.quote(group, safe="/")
+            extra_params = f"{extra_params}&group={quoted_group}"
     else:
         prefix = "/rasterio"
         extra_params = ""
@@ -333,6 +542,7 @@ def _build_links(
 def evaluate_concept_compatibility(
     concept_id: str,
     request: Request,
+    group: str | None = None,
 ) -> CompatibilityResponse:
     """Test which reader backend is compatible with a CMR concept.
 
@@ -359,9 +569,15 @@ def evaluate_concept_compatibility(
     # Try xarray first
     xarray_error: Exception | None = None
     try:
-        result = evaluate_xarray_compatibility(concept_id, request)
+        result = evaluate_xarray_compatibility(concept_id, request, group=group)
         first_var = next(iter(result.get("variables") or {}), None)
-        links = _build_links(base_url, concept_id, "xarray", first_var)
+        links = _build_links(
+            base_url,
+            concept_id,
+            "xarray",
+            first_var,
+            group or result.get("sampled_group") or result.get("default_group"),
+        )
         return CompatibilityResponse(
             concept_id=concept_id,
             datetime=temporal_extent,
@@ -404,6 +620,9 @@ def _concept_id_param(
     return collection_concept_id or concept_id
 
 
+XarrayGroupParam: TypeAlias = cast(Any, XarrayIOParams.__annotations__["group"])
+
+
 router = APIRouter()
 
 
@@ -411,8 +630,9 @@ router = APIRouter()
 def compatibility_check(
     request: Request,
     concept_id: Optional[str] = Depends(_concept_id_param),
+    group: XarrayGroupParam = None,
 ) -> CompatibilityResponse:
     """Check which backend is compatible with a CMR collection concept."""
     if concept_id is None:
         raise HTTPException(status_code=400, detail="concept_id is required")
-    return evaluate_concept_compatibility(concept_id, request)
+    return evaluate_concept_compatibility(concept_id, request, group=group)

--- a/titiler/cmr/compatibility.py
+++ b/titiler/cmr/compatibility.py
@@ -262,44 +262,39 @@ def _candidate_group_paths(
     credential_provider: Any = None,
 ) -> list[str]:
     """Return likely xarray group paths, preferring spatial non-metadata groups."""
-    reader = _make_blockstore_reader(
-        src_path,
-        auth_token=auth_token,
-        credential_provider=credential_provider,
-    )
-    try:
-        with h5py.File(reader, "r") as file_handle:
-            all_group_paths: list[str] = []
-            spatial_group_paths: list[str] = []
-            spatial_metadata_group_paths: list[str] = []
+    all_group_paths: list[str] = []
+    spatial_group_paths: list[str] = []
+    spatial_metadata_group_paths: list[str] = []
 
-            def visitor(name: str, obj: Any) -> None:
-                if not name or not isinstance(obj, h5py.Group):
-                    return
+    def visitor(name: str, obj: Any) -> None:
+        if not (
+            name
+            and isinstance(obj, h5py.Group)
+            and any(isinstance(child, h5py.Dataset) for child in obj.values())
+        ):
+            return
 
-                if not any(isinstance(child, h5py.Dataset) for child in obj.values()):
-                    return
+        all_group_paths.append(name)
 
-                all_group_paths.append(name)
+        if not _group_has_spatial_dims(obj):
+            return
 
-                if not _group_has_spatial_dims(obj):
-                    return
+        if "/metadata/" in f"/{name.strip('/')}/":
+            spatial_metadata_group_paths.append(name)
+        else:
+            spatial_group_paths.append(name)
 
-                normalized_name = f"/{name.strip('/')}/"
-                if "/metadata/" in normalized_name:
-                    spatial_metadata_group_paths.append(name)
-                else:
-                    spatial_group_paths.append(name)
+    with (
+        _make_blockstore_reader(
+            src_path,
+            auth_token=auth_token,
+            credential_provider=credential_provider,
+        ) as reader,
+        h5py.File(reader, "r") as file_handle,
+    ):
+        file_handle.visititems(visitor)
 
-            file_handle.visititems(visitor)
-
-            if spatial_group_paths:
-                return spatial_group_paths
-            if spatial_metadata_group_paths:
-                return spatial_metadata_group_paths
-            return all_group_paths
-    finally:
-        reader.close()
+    return spatial_group_paths or spatial_metadata_group_paths or all_group_paths
 
 
 def _compatible_groups(

--- a/titiler/cmr/compatibility.py
+++ b/titiler/cmr/compatibility.py
@@ -66,12 +66,9 @@ class CompatibilityResponse(BaseModel):
     variables: Optional[Dict[str, VariableInfo]] = None
     dimensions: Optional[Dict[str, int]] = None
     coordinates: Optional[Dict[str, CoordinateInfo]] = None
+    compatible_groups: Optional[List[str]] = None
     example_assets: Optional[Dict[str, str] | str] = None
     sample_asset_raster_info: Optional[Info] = None
-    requires_group: Optional[bool] = None
-    group_hints: Optional[List[str]] = None
-    default_group: Optional[str] = None
-    sampled_group: Optional[str] = None
     links: Optional[List[TemplateLink]] = None
 
 
@@ -304,54 +301,25 @@ def _candidate_group_paths(
         reader.close()
 
 
-def _group_hints(
+def _compatible_groups(
     src_path: str,
     auth_token: str | None = None,
     credential_provider: Any = None,
-) -> dict[str, Any]:
-    """Inspect a hierarchical asset and return lightweight xarray group hints."""
+) -> list[str]:
+    """Return candidate group paths for hierarchical assets.
+
+    This stays intentionally lightweight. It only scans HDF5 groups for datasets
+    with spatial dimension aliases and does not open each candidate with xarray.
+    """
     try:
-        group_paths = _candidate_group_paths(
+        return _candidate_group_paths(
             src_path,
             auth_token=auth_token,
             credential_provider=credential_provider,
         )
     except Exception as exc:
         logger.info("Skipping group inspection for %s: %s", src_path, exc)
-        return {
-            "requires_group": False,
-            "group_hints": [],
-            "default_group": None,
-            "sampled_group": None,
-        }
-
-    group_hints: list[str] = []
-    for group_path in group_paths:
-        try:
-            grouped_dataset = open_dataset(
-                src_path,
-                group=group_path,
-                credential_provider=credential_provider,
-                auth_token=auth_token,
-            )
-        except Exception as exc:
-            logger.info(
-                "Skipping incompatible group %s for %s: %s",
-                group_path,
-                src_path,
-                exc,
-            )
-            continue
-
-        if grouped_dataset.data_vars:
-            group_hints.append(group_path)
-
-    return {
-        "requires_group": False,
-        "group_hints": group_hints,
-        "default_group": group_hints[0] if len(group_hints) == 1 else None,
-        "sampled_group": group_hints[0] if group_hints else None,
-    }
+        return []
 
 
 def evaluate_xarray_compatibility(
@@ -407,28 +375,14 @@ def evaluate_xarray_compatibility(
         auth_token=auth_token,
     )
     result = extract_xarray_metadata(ds)
-    group_hints = _group_hints(
-        href,
-        auth_token=auth_token,
-        credential_provider=credential_provider,
-    )
 
-    sampled_group = group if group else group_hints.get("sampled_group")
-    if not group and not result["variables"] and sampled_group:
-        sampled_ds = open_dataset(
+    if not group and not result["variables"]:
+        result["compatible_groups"] = _compatible_groups(
             href,
-            group=sampled_group,
-            credential_provider=credential_provider,
             auth_token=auth_token,
+            credential_provider=credential_provider,
         )
-        result = extract_xarray_metadata(sampled_ds)
 
-    group_hints["requires_group"] = (
-        bool(group_hints["group_hints"]) and not bool(group) and not bool(ds.data_vars)
-    )
-    group_hints["sampled_group"] = sampled_group
-
-    result.update(group_hints)
     result["example_assets"] = href
     return result
 
@@ -502,7 +456,10 @@ def _build_links(
     group: Optional[str] = None,
 ) -> List[TemplateLink]:
     """Build template links for the compatibility response."""
-    if backend == "xarray" and first_var:
+    if backend == "xarray":
+        if not first_var:
+            return []
+
         prefix = "/xarray"
         extra_params = f"&variables={first_var}"
         if group:
@@ -576,7 +533,7 @@ def evaluate_concept_compatibility(
             concept_id,
             "xarray",
             first_var,
-            group or result.get("sampled_group") or result.get("default_group"),
+            group,
         )
         return CompatibilityResponse(
             concept_id=concept_id,

--- a/titiler/cmr/compatibility.py
+++ b/titiler/cmr/compatibility.py
@@ -168,7 +168,7 @@ def extract_xarray_metadata(
 
     return {
         "variables": variables,
-        "dimensions": dict(ds.dims),
+        "dimensions": dict(ds.sizes),
         "coordinates": coordinates,
         "backend": "xarray",
     }

--- a/uv.lock
+++ b/uv.lock
@@ -5112,7 +5112,7 @@ wheels = [
 
 [[package]]
 name = "titiler-cmr"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
This adds the ability to inspect hierarchically organized HDF5 files. Now if the sample granule has nested groups it will check the dimensions of each group and return a list of `compatible_groups` that should be accessible for titiler-cmr. It won't inspect variables across all of the possible groups but there is a new `group` query parameter on the compatibility endpoint which can be used to learn about the variables within a single group (once you know what the groups are).

resolves #185