### PR TITLE
fix: do not ignore case when parsing expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ notebooks/
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode
+
+issue-drafts/

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -148,6 +148,15 @@ def test_cmr_assets_expr_params_legacy_with_assets():
     assert params.expression == "(b2-b1)/(b2+b1)"
 
 
+def test_cmr_assets_expr_params_legacy_with_two_digit_band_names():
+    """Uppercase asset names like B11 should not be mistaken for b11 band refs."""
+    params = CMRAssetsExprParams(
+        assets=["B11", "B12"], expression="(B11-B12)/(B11+B12)"
+    )
+    assert list(params.assets) == ["B11", "B12"]
+    assert params.expression == "(b1-b2)/(b1+b2)"
+
+
 def test_cmr_assets_expr_params_new_style_passthrough():
     """New-style expression (b1, b2, ...) passes through unchanged."""
     params = CMRAssetsExprParams(assets=["B04", "B05"], expression="(b1-b2)/(b1+b2)")

--- a/titiler/cmr/dependencies.py
+++ b/titiler/cmr/dependencies.py
@@ -172,7 +172,7 @@ def _translate_legacy_expr(expression: str, names: list[str]) -> str:
     in `names`.
     """
     identifiers = re.findall(r"\b([a-zA-Z_]\w*)\b(?!\s*\()", expression)
-    new_style = re.compile(r"^b[1-9][0-9]*$", re.IGNORECASE)
+    new_style = re.compile(r"^b[1-9][0-9]*$")
     legacy = list(dict.fromkeys(n for n in identifiers if not new_style.match(n)))
     if not legacy:
         return expression
@@ -211,7 +211,7 @@ class CMRAssetsExprParams(AssetsExprParams):
             return
 
         identifiers = re.findall(r"\b([a-zA-Z_]\w*)\b(?!\s*\()", self.expression)
-        new_style_pattern = re.compile(r"^b[1-9][0-9]*$", re.IGNORECASE)
+        new_style_pattern = re.compile(r"^b[1-9][0-9]*$")
         asset_names = list(
             dict.fromkeys(
                 name for name in identifiers if not new_style_pattern.match(name)

--- a/uv.lock
+++ b/uv.lock
@@ -5112,7 +5112,7 @@ wheels = [
 
 [[package]]
 name = "titiler-cmr"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
This PR covers a case where the input expression with semantic band names was interpreted as an expression with sequential band names because of the case (upper/lower) of the band values. See https://github.com/developmentseed/titiler-cmr/issues/187 for more context.

I think we should patch this now but I think this expression parsing logic is too brittle and we should consider forcing users to use sequential band names in expressions rather than trying to interpret the input in this way.

resolves #187 