### PR TITLE
chore: upgrade to node v22

### DIFF
--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Install node and related deps
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
-        node-version: 20
+        node-version: 22
 
     - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:


### PR DESCRIPTION
The Node.js 20.x Lambda runtime reached End-Of-Life (EOL) on April 30, 2026.

We got a notification that we need to update our titiler-cmr lambdas to use a support runtime: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported


