### PR TITLE
chore(deps): upgrade aws-cdk-lib to upgrade Node.js runtime

### DIFF
--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -32,10 +32,6 @@ runs:
         path: ~/.npm
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
 
-    - name: Install AWS CDK
-      shell: bash
-      run: npm install -g aws-cdk@2
-
     - name: Install uv
       uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       with:
@@ -45,8 +41,8 @@ runs:
       shell: bash
       working-directory: ${{ inputs.dir }}
       run: |
-        uv sync --only-group deployment
-        uv run npm install
+        uv sync --group deployment
+        npm ci
 
     - name: Get relevant environment configuration from aws secrets
       if: inputs.env_aws_secret_name != ''
@@ -56,12 +52,12 @@ runs:
         AWS_DEFAULT_REGION: us-west-2
         SCRIPT_PATH: ${{ inputs.script_path }}
         ENV_AWS_SECRET_NAME: ${{ inputs.env_aws_secret_name }}
-      run: uv run --only-group deployment "${SCRIPT_PATH}" --secret-id "${ENV_AWS_SECRET_NAME}"
+      run: uv run --group deployment "${SCRIPT_PATH}" --secret-id "${ENV_AWS_SECRET_NAME}"
 
     - name: CDK Synth
       shell: bash
       working-directory: ${{ inputs.dir }}
-      run: uv run --only-group deployment npm run cdk -- synth
+      run: uv run --group deployment npm run cdk -- synth
 
     - name: Check Asset Sizes
       shell: bash
@@ -84,5 +80,5 @@ runs:
       if: ${{ inputs.skip_deploy == 'false' }}
       id: deploy_titiler_cmr_stack
       working-directory: ${{ inputs.dir }}
-      run: uv run cdk deploy --all --require-approval never --outputs-file ${HOME}/cdk-outputs.json
+      run: uv run --group deployment npm run cdk -- deploy --all --require-approval never --outputs-file ${HOME}/cdk-outputs.json
       shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ ENV/
 
 # AWS CDK
 cdk.out/
+cdk.out.test/
 node_modules
 
 notebooks/

--- a/README.md
+++ b/README.md
@@ -166,6 +166,20 @@ The environment variables which should be set in the `veda-deploy` AWS secret ar
 
 You can trigger a deploy to a "dev" stack (cloudformation stack name should be `titiler-cmr-dev`) in the VEDA SMCE account by labeling a PR with the "deploy-dev" tag. This stack is intended for testing new features.
 
+### Local CDK synth validation
+
+To validate that the CDK app still synthesizes locally without using real secrets, run:
+
+```bash
+./scripts/test-cdk-synth.sh
+```
+
+The script installs the deployment dependencies, installs the local CDK CLI from `infrastructure/aws/package-lock.json`, and synthesizes the stack with placeholder Earthdata credentials. Override any environment variable if you want to test a different configuration, for example:
+
+```bash
+STAGE=staging TITILER_CMR_ROOT_PATH=/api/titiler-cmr ./scripts/test-cdk-synth.sh
+```
+
 ## Contribution & Development
 
 See [CONTRIBUTING.md](https://github.com/developmentseed/titiler-cmr/blob/develop/CONTRIBUTING.md)

--- a/infrastructure/aws/package-lock.json
+++ b/infrastructure/aws/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "cdk": "^2.177.0"
+        "cdk": "^2.1126.0"
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1114.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1114.1.tgz",
-      "integrity": "sha512-jMaKPWQQs1G6AbhfCQG2zGrgAhTxzP0jn4T2CuwONuvcV374dMPhfC/LBAv48ruSOgpCK9x6V1xeO/aH3EchAA==",
+      "version": "2.1126.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1126.0.tgz",
+      "integrity": "sha512-uNoocb3vCPiAT3j9+SwL6pn/VVggHWBsgC2XpxyhNvYQYt6cE9BM/149GWwtdcwnLrPjnwW1+CV/5nSSh5dV+w==",
       "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
@@ -25,12 +25,12 @@
       }
     },
     "node_modules/cdk": {
-      "version": "2.1114.1",
-      "resolved": "https://registry.npmjs.org/cdk/-/cdk-2.1114.1.tgz",
-      "integrity": "sha512-gleHqKdqVQmtpwVngMM9rjiAxNUV+4tgS1heIifjlQ1viLDLz7j0f1uW7cI9DrLxFLhH//h2ZViyl5Es0iVUMw==",
+      "version": "2.1126.0",
+      "resolved": "https://registry.npmjs.org/cdk/-/cdk-2.1126.0.tgz",
+      "integrity": "sha512-80tH/5EjMRHShom0LMFb6B6/SrYNrAGalY8gC4cXkEt4yvFlfc9A3fe/KqNByKmUL8kjSQChvfRoZ3YcX1Zv+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "aws-cdk": "2.1114.1"
+        "aws-cdk": "2.1126.0"
       },
       "bin": {
         "cdk": "bin/cdk"
@@ -42,16 +42,16 @@
   },
   "dependencies": {
     "aws-cdk": {
-      "version": "2.1114.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1114.1.tgz",
-      "integrity": "sha512-jMaKPWQQs1G6AbhfCQG2zGrgAhTxzP0jn4T2CuwONuvcV374dMPhfC/LBAv48ruSOgpCK9x6V1xeO/aH3EchAA=="
+      "version": "2.1126.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1126.0.tgz",
+      "integrity": "sha512-uNoocb3vCPiAT3j9+SwL6pn/VVggHWBsgC2XpxyhNvYQYt6cE9BM/149GWwtdcwnLrPjnwW1+CV/5nSSh5dV+w=="
     },
     "cdk": {
-      "version": "2.1114.1",
-      "resolved": "https://registry.npmjs.org/cdk/-/cdk-2.1114.1.tgz",
-      "integrity": "sha512-gleHqKdqVQmtpwVngMM9rjiAxNUV+4tgS1heIifjlQ1viLDLz7j0f1uW7cI9DrLxFLhH//h2ZViyl5Es0iVUMw==",
+      "version": "2.1126.0",
+      "resolved": "https://registry.npmjs.org/cdk/-/cdk-2.1126.0.tgz",
+      "integrity": "sha512-80tH/5EjMRHShom0LMFb6B6/SrYNrAGalY8gC4cXkEt4yvFlfc9A3fe/KqNByKmUL8kjSQChvfRoZ3YcX1Zv+Q==",
       "requires": {
-        "aws-cdk": "2.1114.1"
+        "aws-cdk": "2.1126.0"
       }
     }
   }

--- a/infrastructure/aws/package.json
+++ b/infrastructure/aws/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "cdk": "^2.177.0"
+    "cdk": "^2.1126.0"
   },
   "scripts": {
     "cdk": "cdk"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dev = [
     "uvicorn>=0.41.0",
 ]
 deployment = [
-    "aws-cdk-lib~=2.177.0",
+    "aws-cdk-lib>=2.258.1",
     "boto3>=1.34.145",
     "constructs>=10.4.2",
     "pydantic-settings~=2.0",

--- a/scripts/test-cdk-synth.sh
+++ b/scripts/test-cdk-synth.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CDK_DIR="${ROOT_DIR}/infrastructure/aws"
+OUT_DIR="${CDK_OUTDIR:-${CDK_DIR}/cdk.out.test}"
+
+export TITILER_CMR_EARTHDATA_USERNAME="${TITILER_CMR_EARTHDATA_USERNAME:-placeholder-username}"
+export TITILER_CMR_EARTHDATA_PASSWORD="${TITILER_CMR_EARTHDATA_PASSWORD:-placeholder-password}"
+export TITILER_CMR_EARTHDATA_S3_DIRECT_ACCESS="${TITILER_CMR_EARTHDATA_S3_DIRECT_ACCESS:-TRUE}"
+export TITILER_CMR_ROOT_PATH="${TITILER_CMR_ROOT_PATH:-}"
+export STAGE="${STAGE:-test}"
+
+cd "${CDK_DIR}"
+
+uv sync --group deployment --inexact
+npm ci
+rm -rf "${OUT_DIR}"
+
+printf 'Synthesizing CDK app with placeholder environment into %s\n' "${OUT_DIR}"
+uv run --group deployment npm run cdk -- synth --output "${OUT_DIR}"

--- a/uv.lock
+++ b/uv.lock
@@ -296,67 +296,52 @@ wheels = [
 
 [[package]]
 name = "aws-cdk-asset-awscli-v1"
-version = "2.2.257"
+version = "2.2.282"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsii" },
     { name = "publication" },
     { name = "typeguard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/ad/3d801f7249e8bef1bb190d58dbdd75a8180e64f74e724220b790d3770d4e/aws_cdk_asset_awscli_v1-2.2.257.tar.gz", hash = "sha256:1f33ba28c1d3874d3a71c95f7b94ecbb102c9bd60c4e1ff696311a47a0f56c35", size = 19746750, upload-time = "2025-10-20T16:04:55.018Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/30/90558d9e05c2b1a5a8d7d87332b4bed4a2e5d2eb04cc7064f6e9e0c8a2f2/aws_cdk_asset_awscli_v1-2.2.282.tar.gz", hash = "sha256:f86e61653927f77fb235b5ec148c955c610117430c869d182c8b20f7e07e2df2", size = 20740538, upload-time = "2026-05-25T21:33:20.444Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/1c/ecb54c68235e7b7bc540537c5de913a6b1f73fd7ed8fead8361563d9bf29/aws_cdk_asset_awscli_v1-2.2.257-py3-none-any.whl", hash = "sha256:d4ca5f5772a45e519100c7292e6f0a1dddff8c7eb6f3e4b79b6d42047dd588f8", size = 19745220, upload-time = "2025-10-20T16:04:52.329Z" },
-]
-
-[[package]]
-name = "aws-cdk-asset-kubectl-v20"
-version = "2.1.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jsii" },
-    { name = "publication" },
-    { name = "typeguard" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/c8/c08645a596532f668a8f2df05e39ea08e00d688919807c0b8dd360e233b5/aws_cdk_asset_kubectl_v20-2.1.4.tar.gz", hash = "sha256:c723c94c6c89283efef779ca44bea8e2e312d49b07bf5beaf6f27340e1fecff4", size = 25455889, upload-time = "2025-02-07T22:10:41.719Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/c7/7b272bc17bdc2079423ad39639832e37d547b53e8708479ec98768a9090e/aws_cdk.asset_kubectl_v20-2.1.4-py3-none-any.whl", hash = "sha256:14a194e14adbf3868a8105b07e8714e10e6621a22beca9b4859a82a9cfbe68f6", size = 25454444, upload-time = "2025-02-07T22:10:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/86/dcb45969f1b34351cfd9afdb6b35bff38a3e929c8bc42b07036879f3a62e/aws_cdk_asset_awscli_v1-2.2.282-py3-none-any.whl", hash = "sha256:24139da0eb1be59f8cfda22c6343d51e8d50bb89b5052b049cfab92683de7790", size = 20738955, upload-time = "2026-05-25T21:33:17.673Z" },
 ]
 
 [[package]]
 name = "aws-cdk-asset-node-proxy-agent-v6"
-version = "2.1.0"
+version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsii" },
     { name = "publication" },
     { name = "typeguard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/ab/09ac3ecc0067988d02398328e088d66cbe8555c991563c8ddfa1db5296ae/aws_cdk_asset_node_proxy_agent_v6-2.1.0.tar.gz", hash = "sha256:1f292c0631f86708ba4ee328b3a2b229f7e46ea1c79fbde567ee9eb119c2b0e2", size = 1540231, upload-time = "2024-09-03T09:36:51.634Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/e3/92e49ecaa002b4ac54371538991389c248577cbae7394ea9d1261ff41078/aws_cdk_asset_node_proxy_agent_v6-2.1.2.tar.gz", hash = "sha256:1340588dd351dcae37e07188f39075364f73ccde6ed9468c1184b06ada4af665", size = 1534674, upload-time = "2026-05-15T08:14:19.895Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/86/1817a6da223aa80aeb94a504f07f930170284694b18f6053729e9930cc6a/aws_cdk.asset_node_proxy_agent_v6-2.1.0-py3-none-any.whl", hash = "sha256:24a388b69a44d03bae6dbf864c4e25ba650d4b61c008b4568b94ffbb9a69e40e", size = 1538724, upload-time = "2024-09-03T09:36:49.8Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/06/29837eb8ae4dc82ed2e593e4b24449394393b9a8a247b0ce2cee811e5cbb/aws_cdk_asset_node_proxy_agent_v6-2.1.2-py3-none-any.whl", hash = "sha256:1028bff16fdb87b8c82404e9b48f32ed383429dece84067f47379c4049da5da4", size = 1533233, upload-time = "2026-05-15T08:14:17.622Z" },
 ]
 
 [[package]]
 name = "aws-cdk-cloud-assembly-schema"
-version = "39.2.20"
+version = "54.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsii" },
     { name = "publication" },
     { name = "typeguard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/a5/929cf149f9224c42cec11b835361d371faeaedfcac17453f2aeb02c5783a/aws_cdk_cloud_assembly_schema-39.2.20.tar.gz", hash = "sha256:e110b22f961d15c25a9099590375280c0b45637c8325ade9b570a0ef11e6e907", size = 188301, upload-time = "2025-02-10T00:25:58.23Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/5d/7538ff6eef7a19a80e13b2cac7171363413fc43161be46a2dffafa279a13/aws_cdk_cloud_assembly_schema-54.2.0.tar.gz", hash = "sha256:2e3a05fca6a28f49811b7b011fce12b03dd0adb15c37a0ad2d1b16d8d66fe95a", size = 281364, upload-time = "2026-06-03T16:16:27.833Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/62/8d34bd0750a2ad9e6d59548119c0230274c225b0a7d0340be1db8d831753/aws_cdk.cloud_assembly_schema-39.2.20-py3-none-any.whl", hash = "sha256:7b1ab0593fbfaac4ff0d5d0aa6a3b54185e0286f4aa68376557cac2d50c59183", size = 187292, upload-time = "2025-02-10T00:25:55.559Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/32/0fecbc4056cc72642189d0f93aebae71501119f56503f2812c77cf8d5b5d/aws_cdk_cloud_assembly_schema-54.2.0-py3-none-any.whl", hash = "sha256:a7038bffa1aaf3365b72147987396bcf0b9951c3b53b2eebfc181b7cb4227067", size = 280444, upload-time = "2026-06-03T16:16:24.697Z" },
 ]
 
 [[package]]
 name = "aws-cdk-lib"
-version = "2.177.0"
+version = "2.258.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aws-cdk-asset-awscli-v1" },
-    { name = "aws-cdk-asset-kubectl-v20" },
     { name = "aws-cdk-asset-node-proxy-agent-v6" },
     { name = "aws-cdk-cloud-assembly-schema" },
     { name = "constructs" },
@@ -364,9 +349,9 @@ dependencies = [
     { name = "publication" },
     { name = "typeguard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bf/47c3c59636645d77ea1021bd2ffacba139165bebe4568c75a5248b740d84/aws_cdk_lib-2.177.0.tar.gz", hash = "sha256:5e51c48da31555beb38243bb2882e98ee9fe1796466ba9f8d3088701b47965e5", size = 38723662, upload-time = "2025-01-25T09:16:01.512Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/f7/2b7bda2c4a8eb5413e5940c640dd952d5ce00683a8ca4089742a75280cf9/aws_cdk_lib-2.258.1.tar.gz", hash = "sha256:a25158952b9e39c7a5ffd3fd1fcf8d769f73454e22394320d9e1c944324956a9", size = 50799708, upload-time = "2026-06-09T09:18:23.689Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/13/5875ae6d2fdbc4aea5650fc2fb89767cd4d7eeda1dcc9a449d904e47eff3/aws_cdk_lib-2.177.0-py3-none-any.whl", hash = "sha256:acdf06aaf52367a64b4bf88381e8272cb7b5961c242020ace822c79749e53cac", size = 39000486, upload-time = "2025-01-25T09:15:14.545Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ee/326682437a52a7aabc5b2b81517eb0d6e07f291044ef837b01291269855c/aws_cdk_lib-2.258.1-py3-none-any.whl", hash = "sha256:eb60a20edcb4a547fa1eb5ed6f3ef16648346a7400821cf4a37b15051adcbe73", size = 51487906, upload-time = "2026-06-09T09:17:40.348Z" },
 ]
 
 [[package]]
@@ -801,16 +786,16 @@ wheels = [
 
 [[package]]
 name = "constructs"
-version = "10.4.3"
+version = "10.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsii" },
     { name = "publication" },
     { name = "typeguard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/e1/48a63ea310ac999005368aa72f52be520210526002f3f0cfcb7aaa9477ee/constructs-10.4.3.tar.gz", hash = "sha256:bfe3657b0acb62af7aa1fda9a7e338ae5cae84ddf8f84f71125a2a3800d52ea0", size = 64486, upload-time = "2025-11-06T15:48:25.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/f57364d14c818108a47e124d1a4cfbee7c9f69ab1263ab59a7087028be18/constructs-10.6.0.tar.gz", hash = "sha256:bc55d1d390142424861e5ff5c6b8c243c4bae18fe7302e0939c2003f329ba365", size = 68788, upload-time = "2026-03-23T09:00:54.242Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/94/a5ce72d63276d3baa47592d3d12afc33f9e5d8f4ddd7bb2ec0012255037f/constructs-10.4.3-py3-none-any.whl", hash = "sha256:43bbefa1ac1c044577d0b1a30648fe5b49557b8b95de2648186f6b909febf7f9", size = 62659, upload-time = "2025-11-06T15:48:21.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/38/6de46d122a2fcd275a5f1fa4ad1d8d2058afd6b72d8db5f0c125515cbb5c/constructs-10.6.0-py3-none-any.whl", hash = "sha256:ad4ffabdb53c17cde00fb94e441a1ba9fddac57c92ad49d263f8dbd416cec513", size = 66969, upload-time = "2026-03-23T09:00:53.041Z" },
 ]
 
 [[package]]
@@ -1817,20 +1802,19 @@ wheels = [
 
 [[package]]
 name = "jsii"
-version = "1.119.0"
+version = "1.134.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "cattrs" },
-    { name = "importlib-resources" },
     { name = "publication" },
     { name = "python-dateutil" },
     { name = "typeguard" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/60/68bf5e617e94a584d2de483bd9162ad408a3a926e8de018bac36e375efec/jsii-1.119.0.tar.gz", hash = "sha256:9f87508908bfa51dd9aac59fdbbeff347ae76377758ea5e5f83f149052211514", size = 625546, upload-time = "2025-11-10T14:35:44.494Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/d3/930a9e4c09a5ef8b9a9d2a54a480a215b2ac16277089b80451998f4c54b3/jsii-1.134.0.tar.gz", hash = "sha256:22aa450dc9538952453dcd4e51de0b9e92e3c94a6b4e468832acbcbd7b124b57", size = 448323, upload-time = "2026-06-03T19:05:01.19Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/0e/ea1db75bcf2f1cf3556110ac60c88ef933bb5b910fa69ec008f726533a7f/jsii-1.119.0-py3-none-any.whl", hash = "sha256:9203200ed5289ecc6198783513cbd7abef53d4f6eac0046181d647fa56eda6ab", size = 601792, upload-time = "2025-11-10T14:35:43.103Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/fc/4d6a3936fc36753c2b9da33fb9816e9928bd93cabefdd9923b8f79a7a169/jsii-1.134.0-py3-none-any.whl", hash = "sha256:c2288ce3568222883e1620dc9c2f2477331d36a4925a84711cf48297ee13cb50", size = 421348, upload-time = "2026-06-03T19:04:59.768Z" },
 ]
 
 [[package]]
@@ -5223,7 +5207,7 @@ provides-extras = ["uvicorn", "lambda"]
 
 [package.metadata.requires-dev]
 deployment = [
-    { name = "aws-cdk-lib", specifier = "~=2.177.0" },
+    { name = "aws-cdk-lib", specifier = ">=2.258.1" },
     { name = "boto3", specifier = ">=1.34.145" },
     { name = "constructs", specifier = ">=10.4.2" },
     { name = "pydantic-settings", specifier = "~=2.0" },
@@ -5370,14 +5354,11 @@ wheels = [
 
 [[package]]
 name = "typeguard"
-version = "4.2.1"
+version = "2.13.3"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/0e/96ec359939521f8c3e6c7b69526afab96fafe0520b5e1b890e061a66abc9/typeguard-4.2.1.tar.gz", hash = "sha256:c556a1b95948230510070ca53fa0341fb0964611bd05d598d87fb52115d65fee", size = 71292, upload-time = "2024-03-24T08:06:18.233Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/38/c61bfcf62a7b572b5e9363a802ff92559cb427ee963048e1442e3aef7490/typeguard-2.13.3.tar.gz", hash = "sha256:00edaa8da3a133674796cf5ea87d9f4b4c367d77476e185e80251cc13dfbb8c4", size = 40604, upload-time = "2021-12-10T21:09:39.158Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/59/e02336eb478ccdfc9bb0d4c27ce04a4260cd8b45aa04f6b00bcfdbb66a2a/typeguard-4.2.1-py3-none-any.whl", hash = "sha256:7da3bd46e61f03e0852f8d251dcbdc2a336aa495d7daff01e092b55327796eb8", size = 34634, upload-time = "2024-03-24T08:06:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bb/d43e5c75054e53efce310e79d63df0ac3f25e34c926be5dffb7d283fb2a8/typeguard-2.13.3-py3-none-any.whl", hash = "sha256:5e3e3be01e887e7eafae5af63d1f36c849aaa94e3a0112097312aabfa16284f1", size = 17605, upload-time = "2021-12-10T21:09:37.844Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
I checked locally and by upgrading to aws-cdk-lib==2.258.1 the runtime should get upgraded to Node.js 22.x

resolves #191 