### PR TITLE
fix(timeseries): tolerate intervals with no valid pixels in /timeseries/statistics

### DIFF
--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -421,3 +421,71 @@ def test_build_request_urls_multi_value_pass_through() -> None:
     assert "step" not in parsed
     assert parsed["collection_concept_id"] == ["C123"]
     assert parsed["temporal"] == ["2024-01-01T00:00:00Z/2024-01-01T23:59:59Z"]
+
+
+def test_timeseries_statistics_empty_interval(app, mocker, mn_geojson):
+    """An interval with no valid pixels yields null stats; the whole series must
+    still return 200.
+
+    Regression for the response-model 500: ``/statistics`` returns ``null`` for
+    the numeric fields of an empty interval, and re-validating those against
+    rio-tiler's ``BandStatistics`` used to fail the entire timeseries response.
+    """
+    from httpx2 import Response
+
+    # A ``/statistics`` response for an interval with no valid pixels.
+    empty_stats = {
+        **mn_geojson,
+        "properties": {
+            "statistics": {
+                "b1": {
+                    "min": None,
+                    "max": None,
+                    "mean": None,
+                    "count": 0.0,
+                    "sum": 0.0,
+                    "std": None,
+                    "median": None,
+                    "majority": None,
+                    "minority": None,
+                    "unique": 0.0,
+                    "histogram": [[], []],
+                    "valid_percent": 0.0,
+                    "masked_pixels": 100.0,
+                    "valid_pixels": 0.0,
+                    "percentile_2": None,
+                    "percentile_98": None,
+                    "description": "b1",
+                }
+            }
+        },
+    }
+
+    async def mock_timestep_request(client, url, **kwargs):
+        return Response(status_code=200, json=empty_stats)
+
+    mocker.patch("titiler.cmr.timeseries._timestep_request", new=mock_timestep_request)
+    # Skip the CMR request-size pre-check (and its HTTP call).
+    mocker.patch(
+        "titiler.cmr.timeseries.calculate_time_series_request_size",
+        return_value=1.0,
+    )
+
+    response = app.post(
+        "/rasterio/timeseries/statistics",
+        params={
+            "collection_concept_id": "C2021957657-LPCLOUD",
+            "assets_regex": "Fmask",
+            "assets": "Fmask",
+            "temporal": "2024-01-01T00:00:00Z/2024-03-01T00:00:00Z",
+            "step": "P1M",
+        },
+        json=mn_geojson,
+    )
+
+    assert response.status_code == 200
+    stats = response.json()["properties"]["statistics"]
+    # Both monthly intervals are present despite their null statistics.
+    assert len(stats) == 2
+    for interval_stats in stats.values():
+        assert interval_stats["b1"]["valid_pixels"] == 0.0

--- a/titiler/cmr/timeseries.py
+++ b/titiler/cmr/timeseries.py
@@ -41,7 +41,6 @@ from titiler.core.algorithm import algorithms as available_algorithms
 from titiler.core.dependencies import CoordCRSParams, DefaultDependency, DstCRSParams
 from titiler.core.factory import BaseFactory, FactoryExtension
 from titiler.core.models.mapbox import TileJSON
-from titiler.core.models.responses import Statistics
 from titiler.core.resources.enums import ImageType
 from titiler.core.resources.responses import GeoJSONResponse
 
@@ -92,7 +91,15 @@ class TimeseriesImageType(str, Enum):
         return TimeseriesMediaType[self._name_].value
 
 
-TimeseriesStatistics = Dict[str, Statistics]
+# Per-interval statistics, keyed by interval then by band name:
+# ``{interval: {band: {stat: value}}}``. The per-band stats are taken verbatim
+# from the ``/statistics`` sub-responses, which report ``null`` for the numeric
+# fields (min/max/mean/...) of an interval that has no valid pixels. rio-tiler's
+# ``BandStatistics`` model requires those fields to be numbers, so re-validating
+# the sub-responses against it would raise a 500 for the *whole* series whenever
+# a single interval is empty. Keep the per-band leaf permissive so empty
+# intervals pass through unchanged.
+TimeseriesStatistics = Dict[str, Dict[str, Dict[str, Any]]]
 
 
 class TimeseriesStatisticsInGeoJSON(BaseModel):
@@ -547,8 +554,8 @@ class TimeseriesExtension(FactoryExtension):
         async def timeseries_geojson_statistics(
             request: Request,
             geojson: Annotated[
-                Union[FeatureCollection, Feature],
-                Body(description="GeoJSON Feature or FeatureCollection.", embed=False),
+                Feature,
+                Body(description="GeoJSON Feature.", embed=False),
             ],
             query=Depends(timeseries_cmr_query_no_bbox),
             coord_crs=Depends(CoordCRSParams),
@@ -628,10 +635,6 @@ class TimeseriesExtension(FactoryExtension):
             )
             combine_start = time()
             datetime_strs = [d.temporal for d in query]
-            if not isinstance(geojson, Feature):
-                raise HTTPException(
-                    status_code=400, detail="Expected a GeoJSON Feature"
-                )
             if geojson.properties is None:
                 geojson.properties = {}
             geojson.properties["statistics"] = {}


### PR DESCRIPTION
## What

Fixes a `500` from `POST /{backend}/timeseries/statistics` whenever one of the intervals has no valid pixels.

Closes #195.

## Root cause

For each interval, the handler fetches `/statistics` and stores the sub-response's `properties.statistics` verbatim under `geojson.properties["statistics"][interval]`. When an interval has **no valid pixels**, that sub-response reports `null` for the numeric `BandStatistics` fields (`min`, `max`, `mean`, `std`, `median`, `majority`, `minority`).

The endpoint's `response_model` then re-validates the assembled output, and `TimeseriesStatistics = Dict[str, Statistics]` resolves the per-band leaf to rio-tiler's `BandStatistics`, whose numeric fields are required floats. `null` is not a valid float, so FastAPI's response validation fails and the **entire** series 500s — even though every other interval is fine. (rio-tiler builds those stats with `NaN` and serialises `NaN → null`, but `null` does not round-trip back through validation.)

A second, smaller inconsistency: the body is typed `Feature | FeatureCollection`, but the handler only supports a single `Feature` and raised `400 "Expected a GeoJSON Feature"` for a `FeatureCollection` at runtime.

## Change

- Relax the per-band leaf of `TimeseriesStatistics` to a permissive mapping so empty-interval `null` stats pass through unchanged (the sub-responses are already validated by `/statistics`; re-validating them strictly is what broke).
- Narrow the request body to `Feature` and drop the now-dead `"Expected a GeoJSON Feature"` branch, so the advertised input matches what is actually supported.

## Test

Adds `test_timeseries_statistics_empty_interval`, which posts a two-interval series where every interval returns null stats and asserts a `200` with both intervals present. It fails before this change (500) and passes after. The sub-requests and the CMR size pre-check are mocked, so it needs no cassette.

## Reproduction (before the fix)

```bash
FEATURE='{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-115.85,40.60],[-115.65,40.60],[-115.65,40.75],[-115.85,40.75],[-115.85,40.60]]]}}'
curl -s -X POST "https://staging.openveda.cloud/api/titiler-cmr/rasterio/timeseries/statistics?collection_concept_id=C2617126679-POCLOUD&assets=B01_WTR&assets_regex=B%5B0-9%5D%7B2%7D_%5BA-Z%5D%2B&temporal=2024-05-01T00:00:00Z/2024-08-31T23:59:59Z&step=P1M&categorical=true&bounding_box=-115.85,40.60,-115.65,40.75" \
  -H 'Content-Type: application/json' -d "$FEATURE" -w '\nHTTP %{http_code}\n'
# -> 500; the August interval has null min/max/mean/... (no valid pixels)
```
