### PR TITLE
ci: set default branch to main in deploy-dev action workflow

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -10,7 +10,7 @@ on:
       branch:
         description: "Branch to deploy"
         required: true
-        default: "develop"
+        default: "main"
   pull_request:
     types: [labeled, synchronize]
 


### PR DESCRIPTION
I was confused when trying to run the deploy-dev action with the default settings because I didn't notice that it was still trying to deploy the non-existent `develop` branch!