### PR TITLE
fix: add granule_ur to compatibility params and response

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See also the [API documentation](https://staging.openveda.cloud/api/titiler-cmr/
 
 - Render tiles from assets discovered via queries to [NASA's CMR](https://cmr.earthdata.nasa.gov/search)
 - Two backends: **xarray** (`/xarray`) for NetCDF/HDF5 datasets and **rasterio** (`/rasterio`) for GeoTIFF/COG assets
-- `/compatibility` helps inspect sample granules, including optional `granule_ur` and `group` selection plus lightweight group discovery for hierarchical HDF5 and NetCDF assets
+- `/compatibility` helps inspect sample granules, including optional `granule_ur`, `group`, and `skip_variable_statistics` controls plus lightweight group discovery for hierarchical HDF5 and NetCDF assets
 - Timeseries endpoints for generating GIFs, statistics, and tilejsons across a temporal range
 - Queries CMR directly via the [granule search API](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html)
 - Built on top of [titiler](https://github.com/developmentseed/titiler)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See also the [API documentation](https://staging.openveda.cloud/api/titiler-cmr/
 
 - Render tiles from assets discovered via queries to [NASA's CMR](https://cmr.earthdata.nasa.gov/search)
 - Two backends: **xarray** (`/xarray`) for NetCDF/HDF5 datasets and **rasterio** (`/rasterio`) for GeoTIFF/COG assets
-- `/compatibility` helps inspect sample granules, including optional `group` selection and lightweight group discovery for hierarchical HDF5 and NetCDF assets
+- `/compatibility` helps inspect sample granules, including optional `granule_ur` and `group` selection plus lightweight group discovery for hierarchical HDF5 and NetCDF assets
 - Timeseries endpoints for generating GIFs, statistics, and tilejsons across a temporal range
 - Queries CMR directly via the [granule search API](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html)
 - Built on top of [titiler](https://github.com/developmentseed/titiler)

--- a/docs/api/compatibility_api_example.ipynb
+++ b/docs/api/compatibility_api_example.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# How to use the Compatibility API\n",
     "\n",
-    "The `/compatibility` endpoint helps you understand how to call TiTiler-CMR for a collection. For hierarchical HDF5 and NetCDF datasets it can return a lightweight list of candidate `group` paths from the root request, then let you inspect variables by making a follow-up request with `group=...`.\n",
+    "The `/compatibility` endpoint helps you understand how to call TiTiler-CMR for a collection. It returns the sampled `granule_ur` and accepts `granule_ur` when you want to inspect a specific granule. For hierarchical HDF5 and NetCDF datasets it can return a lightweight list of candidate `group` paths from the root request, then let you inspect variables by making a follow-up request with `group=...`.\n",
     "\n",
     "This notebook demonstrates that workflow for the [NISAR Beta Geocoded Polarimetric Covariance (GCOV)](https://www.earthdata.nasa.gov/data/catalog/asf-nisar-l2-gcov-beta-v1-1) collection, which is a known example of a hierarchical HDF5 dataset that needs a `group` parameter for xarray requests.\n",
     "\n",
@@ -89,8 +89,9 @@
    "source": [
     "## Interpret the response\n",
     "\n",
-    "For hierarchical datasets, a root `/compatibility` request stays lightweight. The most important field is:\n",
+    "For hierarchical datasets, a root `/compatibility` request stays lightweight. The most important fields are:\n",
     "\n",
+    "- `granule_ur`: the sampled granule used for this compatibility check\n",
     "- `compatible_groups`: candidate group paths to try in a follow-up request\n",
     "\n",
     "At this stage the response may not include variable metadata or xarray links yet, because TiTiler-CMR has not inspected a nested group."

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -213,6 +213,23 @@ class TestExtractXarrayMetadata:
         assert "min" not in result["coordinates"]["labels"]
         assert "max" not in result["coordinates"]["labels"]
 
+    def test_extract_metadata_can_skip_variable_statistics(self):
+        """Test extracting variable metadata without summary statistics."""
+        dataset = xr.Dataset(
+            {"temperature": (("x",), np.arange(10, dtype=np.float32))},
+            coords={"x": np.arange(10, dtype=np.float32)},
+        )
+
+        result = extract_xarray_metadata(
+            dataset,
+            skip_variable_statistics=True,
+        )
+
+        variable = result["variables"]["temperature"]
+        assert variable == {"shape": [10], "dtype": "float32"}
+        assert result["coordinates"]["x"]["min"] == 0.0
+        assert result["coordinates"]["x"]["max"] == 9.0
+
 
 class TestGroupPruningHelpers:
     """Test HDF5 group pruning helpers."""
@@ -391,6 +408,32 @@ class TestXarrayCompatibility:
         assert search_params.granule_ur == "MOD09A1.A2020001.h12v04.hdf"
         assert result["granule_ur"] == "MOD09A1.A2020001.h12v04.hdf"
 
+    @patch("titiler.cmr.compatibility._compatible_groups")
+    @patch("titiler.cmr.compatibility.open_dataset")
+    @patch("titiler.cmr.compatibility.get_granules")
+    def test_xarray_can_skip_variable_statistics(
+        self,
+        mock_get_granules,
+        mock_open_dataset,
+        mock_compatible_groups,
+    ):
+        """Test xarray compatibility can skip variable summary statistics."""
+        request = _make_request()
+        granule = _make_granule()
+        mock_get_granules.return_value = iter([granule])
+        mock_open_dataset.return_value = xr.Dataset(
+            {"temp": (("x",), np.arange(10, dtype=np.float32))}
+        )
+        mock_compatible_groups.return_value = []
+
+        result = evaluate_xarray_compatibility(
+            "C1234-TEST",
+            request,
+            skip_variable_statistics=True,
+        )
+
+        assert result["variables"]["temp"] == {"shape": [10], "dtype": "float32"}
+
 
 class TestRasterioCompatibility:
     """Test evaluate_rasterio_compatibility function."""
@@ -453,6 +496,36 @@ class TestConceptCompatibility:
         assert result.links is not None
         assert len(result.links) == 3
         mock_xarray.assert_called_once()
+        assert mock_xarray.call_args.kwargs["skip_variable_statistics"] is False
+        mock_rasterio.assert_not_called()
+
+    @patch("titiler.cmr.compatibility.evaluate_rasterio_compatibility")
+    @patch("titiler.cmr.compatibility.evaluate_xarray_compatibility")
+    @patch("titiler.cmr.compatibility.get_collection")
+    def test_skip_variable_statistics_forwards_to_xarray(
+        self, mock_get_collection, mock_xarray, mock_rasterio
+    ):
+        """Test disabling variable statistics forwards to xarray compatibility."""
+        request = _make_request()
+
+        mock_get_collection.return_value = SimpleNamespace(temporal_extents=[])
+        mock_xarray.return_value = {
+            "backend": "xarray",
+            "variables": {"temp": {"shape": [10], "dtype": "float32"}},
+            "dimensions": {},
+            "coordinates": {},
+            "example_assets": "https://example.com/file.nc",
+            "compatible_groups": None,
+        }
+
+        result = evaluate_concept_compatibility(
+            "C1234-TEST",
+            request,
+            skip_variable_statistics=True,
+        )
+
+        assert result.backend == "xarray"
+        assert mock_xarray.call_args.kwargs["skip_variable_statistics"] is True
         mock_rasterio.assert_not_called()
 
     @patch("titiler.cmr.compatibility.evaluate_rasterio_compatibility")
@@ -602,6 +675,7 @@ class TestCompatibilityEndpoint:
         assert data["concept_id"] == "C1234-TEST"
         assert mock_evaluate.call_args.kwargs["group"] is None
         assert mock_evaluate.call_args.kwargs["granule_ur"] is None
+        assert mock_evaluate.call_args.kwargs["skip_variable_statistics"] is False
 
     @patch("titiler.cmr.compatibility.evaluate_concept_compatibility")
     def test_endpoint_accepts_group(self, mock_evaluate, app):
@@ -644,6 +718,25 @@ class TestCompatibilityEndpoint:
             "MOD09A1.A2020001.h12v04.hdf"
         )
 
+    @patch("titiler.cmr.compatibility.evaluate_concept_compatibility")
+    def test_endpoint_accepts_skip_variable_statistics(self, mock_evaluate, app):
+        """Test the endpoint forwards the variable statistics skip flag."""
+        mock_evaluate.return_value = CompatibilityResponse(
+            concept_id="C1234-TEST",
+            backend="xarray",
+            datetime=[],
+            variables={"temp": {"shape": [10], "dtype": "float32"}},
+            links=[],
+        )
+
+        response = app.get(
+            "/compatibility?collection_concept_id=C1234-TEST"
+            "&skip_variable_statistics=true"
+        )
+
+        assert response.status_code == 200
+        assert mock_evaluate.call_args.kwargs["skip_variable_statistics"] is True
+
     def test_endpoint_openapi_documents_optional_parameters(self, app):
         """Test the /compatibility endpoint documents optional sample controls."""
         response = app.get("/api")
@@ -659,3 +752,10 @@ class TestCompatibilityEndpoint:
             param for param in parameters if param["name"] == "granule_ur"
         )
         assert granule_ur_param["description"] == "Unique granule record id"
+        skip_stats_param = next(
+            param for param in parameters if param["name"] == "skip_variable_statistics"
+        )
+        assert skip_stats_param["description"] == (
+            "Skip numeric variable statistics such as min, max, mean, and "
+            "percentiles in xarray compatibility responses."
+        )

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -310,6 +310,7 @@ class TestXarrayCompatibility:
 
         assert result["backend"] == "xarray"
         assert result["example_assets"] == "https://example.com/file.nc"
+        assert result["granule_ur"] == "MOD09A1.A2020001.h12v04.hdf"
         assert result.get("compatible_groups") is None
         assert "temp" in result["variables"]
 
@@ -363,6 +364,33 @@ class TestXarrayCompatibility:
         assert result["compatible_groups"] == ["science/grids/frequencyA"]
         assert result["variables"] == {}
 
+    @patch("titiler.cmr.compatibility._compatible_groups")
+    @patch("titiler.cmr.compatibility.open_dataset")
+    @patch("titiler.cmr.compatibility.get_granules")
+    def test_xarray_uses_requested_granule_ur(
+        self,
+        mock_get_granules,
+        mock_open_dataset,
+        mock_compatible_groups,
+    ):
+        """Test xarray compatibility forwards granule_ur to CMR search."""
+        request = _make_request()
+        granule = _make_granule()
+        mock_get_granules.return_value = iter([granule])
+        mock_open_dataset.return_value = xr.Dataset()
+        mock_compatible_groups.return_value = []
+
+        result = evaluate_xarray_compatibility(
+            "C1234-TEST",
+            request,
+            granule_ur="MOD09A1.A2020001.h12v04.hdf",
+        )
+
+        search_params = mock_get_granules.call_args.kwargs["search_params"]
+        assert search_params.collection_concept_id == "C1234-TEST"
+        assert search_params.granule_ur == "MOD09A1.A2020001.h12v04.hdf"
+        assert result["granule_ur"] == "MOD09A1.A2020001.h12v04.hdf"
+
 
 class TestRasterioCompatibility:
     """Test evaluate_rasterio_compatibility function."""
@@ -382,6 +410,7 @@ class TestRasterioCompatibility:
 
         assert result["backend"] == "rasterio"
         assert isinstance(result["example_assets"], dict)
+        assert result["granule_ur"] == "MOD09A1.A2020001.h12v04.hdf"
         assert result["sample_asset_raster_info"] is info_result
 
     @patch("titiler.cmr.compatibility.get_granules")
@@ -572,6 +601,7 @@ class TestCompatibilityEndpoint:
         assert data["backend"] == "xarray"
         assert data["concept_id"] == "C1234-TEST"
         assert mock_evaluate.call_args.kwargs["group"] is None
+        assert mock_evaluate.call_args.kwargs["granule_ur"] is None
 
     @patch("titiler.cmr.compatibility.evaluate_concept_compatibility")
     def test_endpoint_accepts_group(self, mock_evaluate, app):
@@ -591,8 +621,31 @@ class TestCompatibilityEndpoint:
         assert response.status_code == 200
         assert mock_evaluate.call_args.kwargs["group"] == "science/grids/frequencyA"
 
-    def test_endpoint_openapi_documents_group_like_xarray_routes(self, app):
-        """Test the /compatibility endpoint reuses the shared xarray group parameter docs."""
+    @patch("titiler.cmr.compatibility.evaluate_concept_compatibility")
+    def test_endpoint_accepts_granule_ur(self, mock_evaluate, app):
+        """Test the /compatibility endpoint forwards the optional granule_ur parameter."""
+        mock_evaluate.return_value = CompatibilityResponse(
+            concept_id="C1234-TEST",
+            backend="xarray",
+            datetime=[],
+            granule_ur="MOD09A1.A2020001.h12v04.hdf",
+            links=[],
+        )
+
+        response = app.get(
+            "/compatibility?collection_concept_id=C1234-TEST"
+            "&granule_ur=MOD09A1.A2020001.h12v04.hdf"
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["granule_ur"] == "MOD09A1.A2020001.h12v04.hdf"
+        assert mock_evaluate.call_args.kwargs["granule_ur"] == (
+            "MOD09A1.A2020001.h12v04.hdf"
+        )
+
+    def test_endpoint_openapi_documents_optional_parameters(self, app):
+        """Test the /compatibility endpoint documents optional sample controls."""
         response = app.get("/api")
 
         assert response.status_code == 200
@@ -602,3 +655,7 @@ class TestCompatibilityEndpoint:
             "Select a specific zarr group from a zarr hierarchy. "
             "Could be associated with a zoom level or dataset."
         )
+        granule_ur_param = next(
+            param for param in parameters if param["name"] == "granule_ur"
+        )
+        assert granule_ur_param["description"] == "Unique granule record id"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,31 @@
+"""Tests for CMR Pydantic models."""
+
+from titiler.cmr.models import CollectionSearchResponse
+
+
+def test_collection_resolution_allows_partial_generic_resolution() -> None:
+    """Collection UMM metadata can omit one resolution dimension."""
+    response = CollectionSearchResponse.model_validate(
+        {
+            "items": [
+                {
+                    "umm": {
+                        "TemporalExtents": [],
+                        "SpatialExtent": {
+                            "HorizontalSpatialDomain": {
+                                "ResolutionAndCoordinateSystem": {
+                                    "HorizontalDataResolution": {
+                                        "GenericResolutions": [
+                                            {"YDimension": 250, "Unit": "Not provided"}
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                    }
+                }
+            ]
+        }
+    )
+
+    assert response.items[0].umm.resolution_degrees == (None, None)

--- a/titiler/cmr/compatibility.py
+++ b/titiler/cmr/compatibility.py
@@ -74,7 +74,9 @@ class CompatibilityResponse(BaseModel):
 
 
 def extract_xarray_metadata(
-    ds: Any, max_sample_size: float = 100_000.0
+    ds: Any,
+    max_sample_size: float = 100_000.0,
+    skip_variable_statistics: bool = False,
 ) -> dict[str, Any]:
     """Extract comprehensive metadata from an xarray Dataset.
 
@@ -83,7 +85,9 @@ def extract_xarray_metadata(
     Args:
         ds: xarray Dataset instance
         max_sample_size: Maximum number of elements to sample for statistics.
-            Arrays larger than this will be sampled. Default: 1,000,000
+            Arrays larger than this will be sampled. Default: 100,000.
+        skip_variable_statistics: Whether to skip numeric variable statistics
+            such as min, max, mean, and percentiles.
 
     Returns:
         Dictionary containing variables, dimensions, and coordinates metadata
@@ -95,7 +99,7 @@ def extract_xarray_metadata(
             "dtype": str(ds[var].dtype),
         }
 
-        if ds[var].dtype.kind in {"i", "f", "u"}:
+        if not skip_variable_statistics and ds[var].dtype.kind in {"i", "f", "u"}:
             try:
                 var_data = ds[var]
                 total_size = var_data.size
@@ -350,6 +354,7 @@ def evaluate_xarray_compatibility(
     request: Request,
     group: str | None = None,
     granule_ur: str | None = None,
+    skip_variable_statistics: bool = False,
 ) -> dict[str, Any]:
     """Test XarrayReader compatibility with a concept.
 
@@ -358,6 +363,8 @@ def evaluate_xarray_compatibility(
         request: FastAPI request object
         group: Optional xarray group to inspect
         granule_ur: Optional granule UR to sample
+        skip_variable_statistics: Whether to skip numeric variable statistics
+            such as min, max, mean, and percentiles.
 
     Returns:
         Dictionary with xarray compatibility information
@@ -389,7 +396,10 @@ def evaluate_xarray_compatibility(
         credential_provider=credential_provider,
         auth_token=auth_token,
     )
-    result = extract_xarray_metadata(ds)
+    result = extract_xarray_metadata(
+        ds,
+        skip_variable_statistics=skip_variable_statistics,
+    )
 
     if not group and not result["variables"]:
         result["compatible_groups"] = _compatible_groups(
@@ -509,6 +519,7 @@ def evaluate_concept_compatibility(
     request: Request,
     group: str | None = None,
     granule_ur: str | None = None,
+    skip_variable_statistics: bool = False,
 ) -> CompatibilityResponse:
     """Test which reader backend is compatible with a CMR concept.
 
@@ -520,6 +531,8 @@ def evaluate_concept_compatibility(
         request: FastAPI request object
         group: Optional xarray group to inspect
         granule_ur: Optional granule UR to sample
+        skip_variable_statistics: Whether to skip numeric variable statistics
+            such as min, max, mean, and percentiles.
 
     Returns:
         CompatibilityResponse with backend info, temporal extent, and metadata
@@ -542,6 +555,7 @@ def evaluate_concept_compatibility(
             request,
             group=group,
             granule_ur=granule_ur,
+            skip_variable_statistics=skip_variable_statistics,
         )
         first_var = next(iter(result.get("variables") or {}), None)
         links = _build_links(
@@ -609,6 +623,13 @@ def compatibility_check(
     concept_id: str | None = Depends(_concept_id_param),
     group: XarrayGroupParam = None,
     granule_ur: GranuleUr = None,
+    skip_variable_statistics: bool = Query(
+        default=False,
+        description=(
+            "Skip numeric variable statistics such as min, max, mean, and "
+            "percentiles in xarray compatibility responses."
+        ),
+    ),
 ) -> CompatibilityResponse:
     """Check which backend is compatible with a CMR collection concept."""
     if concept_id is None:
@@ -618,4 +639,5 @@ def compatibility_check(
         request,
         group=group,
         granule_ur=granule_ur,
+        skip_variable_statistics=skip_variable_statistics,
     )

--- a/titiler/cmr/compatibility.py
+++ b/titiler/cmr/compatibility.py
@@ -15,7 +15,7 @@ from titiler.xarray.dependencies import XarrayIOParams
 
 from titiler.cmr.errors import S3CredentialsEndpointMissing
 from titiler.cmr.logger import logger
-from titiler.cmr.models import GranuleSearch
+from titiler.cmr.models import GranuleSearch, GranuleUr
 from titiler.cmr.query import get_collection, get_granules
 from titiler.cmr.reader import (
     X_DIM_NAMES,
@@ -67,6 +67,7 @@ class CompatibilityResponse(BaseModel):
     dimensions: dict[str, int] | None = None
     coordinates: dict[str, CoordinateInfo] | None = None
     compatible_groups: list[str] | None = None
+    granule_ur: str | None = None
     example_assets: dict[str, str] | str | None = None
     sample_asset_raster_info: Info | None = None
     links: list[TemplateLink] | None = None
@@ -318,11 +319,18 @@ def _compatible_groups(
         return []
 
 
-def _sample_granule(concept_id: str, request: Request) -> Any:
-    """Return the first granule for a collection concept."""
+def _sample_granule(
+    concept_id: str,
+    request: Request,
+    granule_ur: str | None = None,
+) -> Any:
+    """Return a sample granule for a collection concept."""
     return next(
         get_granules(
-            search_params=GranuleSearch(collection_concept_id=concept_id),
+            search_params=GranuleSearch(
+                collection_concept_id=concept_id,
+                granule_ur=granule_ur,
+            ),
             client=request.app.state.client,
             page_size=1,
             limit=1,
@@ -341,12 +349,15 @@ def evaluate_xarray_compatibility(
     concept_id: str,
     request: Request,
     group: str | None = None,
+    granule_ur: str | None = None,
 ) -> dict[str, Any]:
     """Test XarrayReader compatibility with a concept.
 
     Args:
         concept_id: CMR concept ID to test
         request: FastAPI request object
+        group: Optional xarray group to inspect
+        granule_ur: Optional granule UR to sample
 
     Returns:
         Dictionary with xarray compatibility information
@@ -361,7 +372,7 @@ def evaluate_xarray_compatibility(
 
     s3_access = request.app.state.s3_access
     auth_token = _get_auth_token(request)
-    granule = _sample_granule(concept_id, request)
+    granule = _sample_granule(concept_id, request, granule_ur=granule_ur)
 
     if granule is None:
         raise ValueError("No assets found for XarrayReader")
@@ -387,6 +398,7 @@ def evaluate_xarray_compatibility(
             credential_provider=credential_provider,
         )
 
+    result["granule_ur"] = granule.granule_ur
     result["example_assets"] = href
     return result
 
@@ -394,12 +406,14 @@ def evaluate_xarray_compatibility(
 def evaluate_rasterio_compatibility(
     concept_id: str,
     request: Request,
+    granule_ur: str | None = None,
 ) -> dict[str, Any]:
     """Test MultiBaseGranuleReader compatibility with a concept.
 
     Args:
         concept_id: CMR concept ID to test
         request: FastAPI request object
+        granule_ur: Optional granule UR to sample
 
     Returns:
         Dictionary with rasterio compatibility information
@@ -415,7 +429,7 @@ def evaluate_rasterio_compatibility(
     s3_access = request.app.state.s3_access
     auth_token = _get_auth_token(request)
     get_s3_credentials = request.app.state.get_s3_credentials
-    granule = _sample_granule(concept_id, request)
+    granule = _sample_granule(concept_id, request, granule_ur=granule_ur)
 
     if granule is None:
         raise ValueError("No assets found for MultiBaseGranuleReader")
@@ -436,6 +450,7 @@ def evaluate_rasterio_compatibility(
 
     return {
         "example_assets": example_assets,
+        "granule_ur": granule.granule_ur,
         "sample_asset_raster_info": info,
         "backend": "rasterio",
     }
@@ -493,6 +508,7 @@ def evaluate_concept_compatibility(
     concept_id: str,
     request: Request,
     group: str | None = None,
+    granule_ur: str | None = None,
 ) -> CompatibilityResponse:
     """Test which reader backend is compatible with a CMR concept.
 
@@ -502,6 +518,8 @@ def evaluate_concept_compatibility(
     Args:
         concept_id: CMR concept ID to test
         request: FastAPI request object
+        group: Optional xarray group to inspect
+        granule_ur: Optional granule UR to sample
 
     Returns:
         CompatibilityResponse with backend info, temporal extent, and metadata
@@ -519,7 +537,12 @@ def evaluate_concept_compatibility(
     # Try xarray first
     xarray_error: Exception | None = None
     try:
-        result = evaluate_xarray_compatibility(concept_id, request, group=group)
+        result = evaluate_xarray_compatibility(
+            concept_id,
+            request,
+            group=group,
+            granule_ur=granule_ur,
+        )
         first_var = next(iter(result.get("variables") or {}), None)
         links = _build_links(
             base_url,
@@ -541,7 +564,11 @@ def evaluate_concept_compatibility(
     # Fall back to rasterio
     rasterio_error: Exception | None = None
     try:
-        result = evaluate_rasterio_compatibility(concept_id, request)
+        result = evaluate_rasterio_compatibility(
+            concept_id,
+            request,
+            granule_ur=granule_ur,
+        )
         links = _build_links(base_url, concept_id, "rasterio")
         return CompatibilityResponse(
             concept_id=concept_id,
@@ -581,8 +608,14 @@ def compatibility_check(
     request: Request,
     concept_id: str | None = Depends(_concept_id_param),
     group: XarrayGroupParam = None,
+    granule_ur: GranuleUr = None,
 ) -> CompatibilityResponse:
     """Check which backend is compatible with a CMR collection concept."""
     if concept_id is None:
         raise HTTPException(status_code=400, detail="concept_id is required")
-    return evaluate_concept_compatibility(concept_id, request, group=group)
+    return evaluate_concept_compatibility(
+        concept_id,
+        request,
+        group=group,
+        granule_ur=granule_ur,
+    )

--- a/titiler/cmr/models.py
+++ b/titiler/cmr/models.py
@@ -3,7 +3,7 @@
 import os
 import re
 from collections import defaultdict
-from typing import Annotated, Any, List, TypeAlias
+from typing import Annotated, Any, List, TypeAlias, cast
 
 from fastapi import Query
 from geojson_pydantic import Feature, FeatureCollection
@@ -405,10 +405,11 @@ class Granule(BaseModel):
 
     def to_feature(self) -> "GranuleFeature":
         """Convert this granule to a GeoJSON Feature."""
+        geometry = cast(Geometry | None, self.geometry)
         return GranuleFeature(
             type="Feature",
-            geometry=self.geometry,
-            bbox=list(self.bbox) if self.geometry else None,
+            geometry=geometry,
+            bbox=self.bbox if geometry else None,
             properties=self.model_dump(exclude={"geometry"}),
         )
 
@@ -491,9 +492,9 @@ class GenericResolution(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    x_dimension: float = Field(alias="XDimension")
-    y_dimension: float = Field(alias="YDimension")
-    unit: str = Field(alias="Unit")
+    x_dimension: float | None = Field(None, alias="XDimension")
+    y_dimension: float | None = Field(None, alias="YDimension")
+    unit: str | None = Field(None, alias="Unit")
 
 
 class HorizontalDataResolution(BaseModel):
@@ -549,7 +550,8 @@ class Collection(BaseModel):
         """Return (x_res, y_res) in decimal degrees, or (None, None) if unavailable.
 
         Meters are converted to degrees using the factor 0.00001 deg/m.
-        Raises ValueError if the unit is not meters or decimal degrees.
+        Returns (None, None) when any resolution component is unavailable.
+        Raises ValueError if a complete resolution uses unsupported units.
         """
         if not (
             (se := self.spatial_extent)
@@ -561,16 +563,18 @@ class Collection(BaseModel):
             return (None, None)
 
         resolution_info = gr[0]
+        unit = resolution_info.unit
+        x_dimension = resolution_info.x_dimension
+        y_dimension = resolution_info.y_dimension
+        if unit is None or x_dimension is None or y_dimension is None:
+            return (None, None)
 
-        units = resolution_info.unit.lower()
+        units = unit.lower()
         if units not in ("meters", "decimal degrees"):
             raise ValueError(f"cannot convert coordinate units: {units}")
 
         factor = 0.00001 if units == "meters" else 1
-        return (
-            resolution_info.x_dimension * factor,
-            resolution_info.y_dimension * factor,
-        )
+        return (x_dimension * factor, y_dimension * factor)
 
 
 class CollectionItem(BaseModel):

--- a/uv.lock
+++ b/uv.lock
@@ -5112,7 +5112,7 @@ wheels = [
 
 [[package]]
 name = "titiler-cmr"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
This makes it possible to test the compatibility of a specific granule, which can be useful since we allow users to make tile requests for specific granules.

I also tucked in a change to one of the pydantic models for CMR collection search results to solve a model validation error when one of the fields was missing.

broken request: `https://v4jec6i5c0.execute-api.us-west-2.amazonaws.com/compatibility?collection_concept_id=C1426396538-LANCEMODIS`

result:
```
{"detail":"1 validation error for CollectionSearchResponse\nitems.0.umm.SpatialExtent.HorizontalSpatialDomain.ResolutionAndCoordinateSystem.HorizontalDataResolution.GenericResolutions.0.XDimension\n  Field required [type=missing, input_value={'YDimension': 250, 'Unit': 'Not provided'}, input_type=dict]\n    For further information visit https://errors.pydantic.dev/2.13/v/missing"}
```

resolves #204